### PR TITLE
fix(tv): refine scale and controls

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/HomeScreen.kt
+++ b/app/src/main/java/com/tuneflow/tv/HomeScreen.kt
@@ -70,8 +70,8 @@ fun HomeScreen(
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 48.dp),
-        verticalArrangement = Arrangement.spacedBy(28.dp),
+        contentPadding = PaddingValues(bottom = 40.dp),
+        verticalArrangement = Arrangement.spacedBy(22.dp),
     ) {
         item {
             HomeHero(
@@ -98,7 +98,7 @@ fun HomeScreen(
         }
 
         if (state.favorites.albums.isNotEmpty() || state.favorites.tracks.isNotEmpty()) {
-            item { SectionHeading("Favorites", "Read-only starred picks from your Navidrome account") }
+            item { SectionHeading("Favorites") }
             item {
                 FavoriteRail(
                     favorites = state.favorites,
@@ -109,7 +109,7 @@ fun HomeScreen(
         }
 
         if (state.artists.isNotEmpty()) {
-            item { SectionHeading("Artists", "Deeper artist browsing with fast album access") }
+            item { SectionHeading("Artists") }
             item {
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                     items(state.artists, key = { it.id }) { artist ->
@@ -120,7 +120,7 @@ fun HomeScreen(
         }
 
         if (state.recentAlbums.isNotEmpty()) {
-            item { SectionHeading("Recent Albums", "New arrivals from your Navidrome library") }
+            item { SectionHeading("Albums") }
             item {
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                     items(state.recentAlbums, key = { it.id }) { album ->
@@ -131,7 +131,7 @@ fun HomeScreen(
         }
 
         if (state.playlists.isNotEmpty()) {
-            item { SectionHeading("Playlists", "Jump back into curated mixes and saved flows") }
+            item { SectionHeading("Playlists") }
             item {
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                     items(state.playlists, key = { it.id }) { playlist ->
@@ -144,27 +144,24 @@ fun HomeScreen(
             }
         }
 
-        item { SectionHeading("Quick Actions", "Fast paths built for remote-first browsing") }
+        item { SectionHeading("Quick Actions") }
         item {
             LazyRow(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                 item {
                     ActionCard(
                         title = "Search",
-                        subtitle = "Find artists, albums, tracks, and recent queries faster.",
                         onClick = onOpenSearch,
                     )
                 }
                 item {
                     ActionCard(
                         title = "Browse Albums",
-                        subtitle = "Explore the full album catalog with larger art-led cards.",
                         onClick = onOpenAlbums,
                     )
                 }
                 item {
                     ActionCard(
                         title = "All Playlists",
-                        subtitle = "Open playlist browser and keep playback flow moving.",
                         onClick = { onOpenPlaylists(null) },
                     )
                 }
@@ -190,8 +187,8 @@ private fun HomeHero(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(360.dp)
-                .clip(RoundedCornerShape(34.dp))
+                .height(286.dp)
+                .clip(RoundedCornerShape(28.dp))
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.82f)),
     ) {
         if (currentItem?.artUrl != null) {
@@ -223,7 +220,7 @@ private fun HomeHero(
         ) {
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Text(
                     text = if (currentItem != null) "Continue Listening" else "Welcome to TuneFlow",
@@ -241,7 +238,7 @@ private fun HomeHero(
                     text =
                         currentItem?.let { "${it.artist} • ${it.album}" }
                             ?: "Calm dark surfaces, large artwork, and fast access to favorites, artists, and search.",
-                    style = MaterialTheme.typography.titleLarge,
+                    style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -260,13 +257,13 @@ private fun HomeHero(
                 }
             }
 
-            Spacer(Modifier.width(24.dp))
+            Spacer(Modifier.width(20.dp))
 
             Box(
                 modifier =
                     Modifier
-                        .size(248.dp)
-                        .clip(RoundedCornerShape(30.dp))
+                        .size(196.dp)
+                        .clip(RoundedCornerShape(24.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.78f)),
                 contentAlignment = Alignment.Center,
             ) {
@@ -303,7 +300,7 @@ private fun HeroActionButton(
         modifier =
             Modifier
                 .then(if (focusedRequester != null) Modifier.focusRequester(focusedRequester) else Modifier)
-                .scale(if (focused) 1.04f else 1f)
+                .scale(if (focused) 1.02f else 1f)
                 .clip(shape)
                 .background(
                     if (accent) {
@@ -327,8 +324,8 @@ private fun HeroActionButton(
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable()
                 .clickable(onClick = onClick)
-                .width(252.dp)
-                .padding(horizontal = 22.dp, vertical = 18.dp),
+                .width(208.dp)
+                .padding(horizontal = 18.dp, vertical = 14.dp),
     ) {
         Text(
             text = label,
@@ -369,7 +366,7 @@ private fun FavoriteTrackCard(
     onClick: () -> Unit,
 ) {
     FocusCard(
-        modifier = Modifier.width(240.dp),
+        modifier = Modifier.width(216.dp),
         onClick = onClick,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -377,8 +374,8 @@ private fun FavoriteTrackCard(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .height(240.dp)
-                        .clip(RoundedCornerShape(22.dp))
+                        .height(216.dp)
+                        .clip(RoundedCornerShape(20.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
             ) {
                 if (track.artUrl != null) {
@@ -421,7 +418,7 @@ private fun HomeArtistCard(
     onClick: () -> Unit,
 ) {
     FocusCard(
-        modifier = Modifier.width(280.dp),
+        modifier = Modifier.width(244.dp),
         onClick = onClick,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -429,8 +426,8 @@ private fun HomeArtistCard(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .height(220.dp)
-                        .clip(RoundedCornerShape(22.dp))
+                        .height(188.dp)
+                        .clip(RoundedCornerShape(20.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
             ) {
                 if (artist.artUrl != null) {
@@ -508,20 +505,12 @@ private fun ErrorBanner(message: String) {
 }
 
 @Composable
-private fun SectionHeading(
-    title: String,
-    subtitle: String,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+private fun SectionHeading(title: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
             text = title,
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -532,7 +521,7 @@ private fun HomeAlbumCard(
     onClick: () -> Unit,
 ) {
     FocusCard(
-        modifier = Modifier.width(240.dp),
+        modifier = Modifier.width(216.dp),
         onClick = onClick,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -540,8 +529,8 @@ private fun HomeAlbumCard(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .height(240.dp)
-                        .clip(RoundedCornerShape(22.dp))
+                        .height(216.dp)
+                        .clip(RoundedCornerShape(20.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
             ) {
                 if (album.artUrl != null) {
@@ -584,21 +573,21 @@ private fun HomePlaylistCard(
     onClick: () -> Unit,
 ) {
     FocusCard(
-        modifier = Modifier.width(300.dp),
+        modifier = Modifier.width(260.dp),
         onClick = onClick,
     ) {
         Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .height(220.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp),
+                    .height(194.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             PlaylistArtCollage(playlist = playlist)
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = playlist.name,
-                    style = MaterialTheme.typography.headlineSmall,
+                    style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
@@ -626,8 +615,8 @@ private fun PlaylistArtCollage(playlist: PlaylistSummary) {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(156.dp)
-                .clip(RoundedCornerShape(22.dp))
+                .height(132.dp)
+                .clip(RoundedCornerShape(18.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
@@ -671,29 +660,23 @@ private fun PlaylistArtCollage(playlist: PlaylistSummary) {
 @Composable
 private fun ActionCard(
     title: String,
-    subtitle: String,
     onClick: () -> Unit,
 ) {
     FocusCard(
-        modifier = Modifier.width(320.dp),
+        modifier = Modifier.width(244.dp),
         onClick = onClick,
     ) {
         Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .height(176.dp),
-            verticalArrangement = Arrangement.SpaceBetween,
+                    .height(104.dp),
+            verticalArrangement = Arrangement.Center,
         ) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.headlineSmall,
+                style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -710,8 +693,8 @@ private fun FocusCard(
     Box(
         modifier =
             modifier
-                .scale(if (focused) 1.04f else 1f)
-                .clip(RoundedCornerShape(26.dp))
+                .scale(if (focused) 1.02f else 1f)
+                .clip(RoundedCornerShape(22.dp))
                 .background(
                     if (focused) {
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
@@ -727,12 +710,12 @@ private fun FocusCard(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
                         },
-                    shape = RoundedCornerShape(26.dp),
+                    shape = RoundedCornerShape(22.dp),
                 )
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable()
                 .clickable(onClick = onClick)
-                .padding(18.dp),
+                .padding(14.dp),
     ) {
         Column(content = content)
     }

--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -70,6 +70,7 @@ class MainActivity : ComponentActivity() {
         val authRepository = AuthRepository(sessionStore)
         val browseRepository = BrowseRepository(sessionStore)
         val playerManager = PlayerGraph.get(applicationContext)
+        val appVersionName = packageManager.getPackageInfo(packageName, 0).versionName ?: "1.0.0"
         startService(Intent(this, TuneFlowPlaybackService::class.java))
 
         setContent {
@@ -90,7 +91,9 @@ class MainActivity : ComponentActivity() {
                     TuneFlowShell(
                         browseRepository = browseRepository,
                         playerManager = playerManager,
+                        sessionStore = sessionStore,
                         searchHistoryStore = searchHistoryStore,
+                        appVersionName = appVersionName,
                         onLogout = {
                             playerManager.stopAndClear()
                             authViewModel.logout()
@@ -122,7 +125,9 @@ private const val NOW_PLAYING_SCREEN_KEY = "nowPlaying"
 private fun TuneFlowShell(
     browseRepository: BrowseRepository,
     playerManager: com.tuneflow.core.player.TvPlayerManager,
+    sessionStore: SessionStore,
     searchHistoryStore: SearchHistoryStore,
+    appVersionName: String,
     onLogout: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -138,6 +143,7 @@ private fun TuneFlowShell(
         viewModel(factory = SearchViewModelFactory(browseRepository, searchHistoryStore))
     val playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel = viewModel(factory = PlaybackViewModelFactory(playerManager))
     val playbackState by playbackViewModel.uiState.collectAsStateWithLifecycle()
+    val session by sessionStore.sessionFlow.collectAsStateWithLifecycle(initialValue = null)
 
     var currentSection by rememberSaveable { mutableStateOf(NavSection.Home) }
     var selectedAlbumId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -251,6 +257,8 @@ private fun TuneFlowShell(
                 onSectionSelected = ::openSection,
                 onNowPlaying = ::openNowPlaying,
                 isNowPlayingActive = showNowPlaying,
+                username = session?.username.orEmpty(),
+                versionName = appVersionName,
                 onLogout = onLogout,
             )
 
@@ -427,26 +435,30 @@ private fun NavRail(
     onSectionSelected: (NavSection) -> Unit,
     onNowPlaying: () -> Unit,
     isNowPlayingActive: Boolean,
+    username: String,
+    versionName: String,
     onLogout: () -> Unit,
 ) {
+    var accountExpanded by rememberSaveable { mutableStateOf(false) }
+
     Column(
         modifier =
             Modifier
-                .width(236.dp)
+                .width(220.dp)
                 .fillMaxHeight()
-                .clip(RoundedCornerShape(30.dp))
+                .clip(RoundedCornerShape(26.dp))
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.72f))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.16f),
-                    shape = RoundedCornerShape(30.dp),
+                    shape = RoundedCornerShape(26.dp),
                 )
-                .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp),
+                .padding(18.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Column(
-            modifier = Modifier.padding(bottom = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(bottom = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalAlignment = Alignment.Start,
         ) {
             Image(
@@ -454,8 +466,8 @@ private fun NavRail(
                 contentDescription = "TuneFlow",
                 modifier =
                     Modifier
-                        .size(68.dp)
-                        .clip(RoundedCornerShape(20.dp)),
+                        .size(60.dp)
+                        .clip(RoundedCornerShape(18.dp)),
             )
             Text(
                 text = "TuneFlow",
@@ -473,22 +485,34 @@ private fun NavRail(
         RailItem(
             label = "Home",
             selected = currentSection == NavSection.Home && !isNowPlayingActive,
-            onClick = { onSectionSelected(NavSection.Home) },
+            onClick = {
+                accountExpanded = false
+                onSectionSelected(NavSection.Home)
+            },
         )
         RailItem(
             label = "Albums",
             selected = currentSection == NavSection.Albums && !isNowPlayingActive,
-            onClick = { onSectionSelected(NavSection.Albums) },
+            onClick = {
+                accountExpanded = false
+                onSectionSelected(NavSection.Albums)
+            },
         )
         RailItem(
             label = "Playlists",
             selected = currentSection == NavSection.Playlists && !isNowPlayingActive,
-            onClick = { onSectionSelected(NavSection.Playlists) },
+            onClick = {
+                accountExpanded = false
+                onSectionSelected(NavSection.Playlists)
+            },
         )
         RailItem(
             label = "Search",
             selected = currentSection == NavSection.Search && !isNowPlayingActive,
-            onClick = { onSectionSelected(NavSection.Search) },
+            onClick = {
+                accountExpanded = false
+                onSectionSelected(NavSection.Search)
+            },
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -496,12 +520,19 @@ private fun NavRail(
         RailItem(
             label = "Now Playing",
             selected = isNowPlayingActive,
-            onClick = onNowPlaying,
+            onClick = {
+                accountExpanded = false
+                onNowPlaying()
+            },
         )
-        RailItem(
-            label = "Logout",
-            selected = false,
-            onClick = onLogout,
+
+        AccountRailSection(
+            username = username.ifBlank { "Account" },
+            versionName = versionName,
+            expanded = accountExpanded,
+            onToggleExpanded = { accountExpanded = !accountExpanded },
+            onExpand = { accountExpanded = true },
+            onLogout = onLogout,
         )
     }
 }
@@ -518,9 +549,9 @@ private fun RailItem(
     Row(
         modifier =
             Modifier
-                .width(196.dp)
-                .scale(if (focused) 1.03f else 1f)
-                .clip(RoundedCornerShape(20.dp))
+                .width(182.dp)
+                .scale(if (focused) 1.02f else 1f)
+                .clip(RoundedCornerShape(18.dp))
                 .background(
                     if (active) {
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
@@ -536,12 +567,12 @@ private fun RailItem(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.16f)
                         },
-                    shape = RoundedCornerShape(20.dp),
+                    shape = RoundedCornerShape(18.dp),
                 )
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable()
                 .clickable(onClick = onClick)
-                .padding(horizontal = 16.dp, vertical = 14.dp),
+                .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -554,5 +585,91 @@ private fun RailItem(
                     MaterialTheme.colorScheme.onSurfaceVariant
                 },
         )
+    }
+}
+
+@Composable
+private fun AccountRailSection(
+    username: String,
+    versionName: String,
+    expanded: Boolean,
+    onToggleExpanded: () -> Unit,
+    onExpand: () -> Unit,
+    onLogout: () -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Row(
+            modifier =
+                Modifier
+                    .width(182.dp)
+                    .scale(if (focused) 1.02f else 1f)
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(
+                        if (focused || expanded) {
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f)
+                        },
+                    )
+                    .border(
+                        width = if (focused || expanded) 2.dp else 1.dp,
+                        color =
+                            if (focused || expanded) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outline.copy(alpha = 0.16f)
+                            },
+                        shape = RoundedCornerShape(18.dp),
+                    )
+                    .onFocusChanged {
+                        focused = it.hasFocus
+                        if (it.hasFocus) onExpand()
+                    }
+                    .focusable()
+                    .clickable(onClick = onToggleExpanded)
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = username,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        if (expanded) {
+            Column(
+                modifier =
+                    Modifier
+                        .width(182.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.46f))
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f),
+                            shape = RoundedCornerShape(18.dp),
+                        )
+                        .padding(14.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text(
+                    text = "App Info",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "Version $versionName",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                RailItem(
+                    label = "Logout",
+                    selected = false,
+                    onClick = onLogout,
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/tuneflow/tv/Theme.kt
+++ b/app/src/main/java/com/tuneflow/tv/Theme.kt
@@ -29,17 +29,17 @@ private val TuneFlowDarkScheme =
 
 private val TuneFlowTypography =
     Typography(
-        displayLarge = TextStyle(fontSize = 68.sp, lineHeight = 72.sp, fontWeight = FontWeight.SemiBold),
-        displayMedium = TextStyle(fontSize = 56.sp, lineHeight = 60.sp, fontWeight = FontWeight.SemiBold),
-        displaySmall = TextStyle(fontSize = 42.sp, lineHeight = 46.sp, fontWeight = FontWeight.SemiBold),
-        headlineLarge = TextStyle(fontSize = 34.sp, lineHeight = 38.sp, fontWeight = FontWeight.SemiBold),
-        headlineMedium = TextStyle(fontSize = 28.sp, lineHeight = 32.sp, fontWeight = FontWeight.SemiBold),
-        headlineSmall = TextStyle(fontSize = 24.sp, lineHeight = 28.sp, fontWeight = FontWeight.Medium),
-        titleLarge = TextStyle(fontSize = 21.sp, lineHeight = 26.sp, fontWeight = FontWeight.Medium),
-        titleMedium = TextStyle(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.Medium),
-        bodyLarge = TextStyle(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.Normal),
-        bodyMedium = TextStyle(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.Normal),
-        labelLarge = TextStyle(fontSize = 14.sp, lineHeight = 18.sp, fontWeight = FontWeight.SemiBold),
+        displayLarge = TextStyle(fontSize = 60.sp, lineHeight = 64.sp, fontWeight = FontWeight.SemiBold),
+        displayMedium = TextStyle(fontSize = 48.sp, lineHeight = 52.sp, fontWeight = FontWeight.SemiBold),
+        displaySmall = TextStyle(fontSize = 34.sp, lineHeight = 38.sp, fontWeight = FontWeight.SemiBold),
+        headlineLarge = TextStyle(fontSize = 30.sp, lineHeight = 34.sp, fontWeight = FontWeight.SemiBold),
+        headlineMedium = TextStyle(fontSize = 24.sp, lineHeight = 28.sp, fontWeight = FontWeight.SemiBold),
+        headlineSmall = TextStyle(fontSize = 21.sp, lineHeight = 25.sp, fontWeight = FontWeight.Medium),
+        titleLarge = TextStyle(fontSize = 19.sp, lineHeight = 24.sp, fontWeight = FontWeight.Medium),
+        titleMedium = TextStyle(fontSize = 17.sp, lineHeight = 22.sp, fontWeight = FontWeight.Medium),
+        bodyLarge = TextStyle(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.Normal),
+        bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.Normal),
+        labelLarge = TextStyle(fontSize = 13.sp, lineHeight = 16.sp, fontWeight = FontWeight.SemiBold),
     )
 
 @Composable

--- a/feature/auth/src/main/java/com/tuneflow/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/tuneflow/feature/auth/LoginScreen.kt
@@ -3,6 +3,8 @@ package com.tuneflow.feature.auth
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,17 +23,21 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.tv.material3.Button
 
 @Composable
 fun LoginScreen(
@@ -53,65 +59,57 @@ fun LoginScreen(
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
-            alpha = 0.28f,
+            alpha = 0.36f,
         )
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.50f)),
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.38f)),
         )
 
         Row(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 68.dp, vertical = 54.dp),
+                    .padding(horizontal = 72.dp, vertical = 48.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(18.dp),
+                modifier = Modifier.weight(1.15f),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 Image(
                     painter = painterResource(id = logoResId),
                     contentDescription = "TuneFlow logo",
                     modifier =
                         Modifier
-                            .size(104.dp)
-                            .clip(RoundedCornerShape(28.dp)),
+                            .size(112.dp)
+                            .clip(RoundedCornerShape(24.dp)),
                 )
                 Text(
                     text = "TuneFlow",
                     style = MaterialTheme.typography.displayMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
-                Text(
-                    text = "A TV-first Navidrome client with smoother focus, richer artwork, and music that feels at home on the big screen.",
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.width(640.dp),
-                )
             }
 
-            Spacer(modifier = Modifier.width(52.dp))
+            Spacer(modifier = Modifier.width(64.dp))
 
             Column(
                 modifier =
                     Modifier
-                        .width(560.dp)
-                        .clip(RoundedCornerShape(30.dp))
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.90f))
+                        .width(484.dp)
+                        .clip(RoundedCornerShape(24.dp))
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.88f))
                         .border(
                             width = 1.dp,
                             color = MaterialTheme.colorScheme.outline.copy(alpha = 0.20f),
-                            shape = RoundedCornerShape(30.dp),
+                            shape = RoundedCornerShape(24.dp),
                         )
-                        .padding(28.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 Text(
                     text = "Sign in",
@@ -119,7 +117,7 @@ fun LoginScreen(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
-                    text = "Use your Navidrome server URL, username, and password to sync your library.",
+                    text = "Use your Navidrome URL, username, and password.",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -155,7 +153,7 @@ fun LoginScreen(
                     )
                 }
 
-                Button(
+                LoginActionButton(
                     onClick = viewModel::login,
                     enabled = !state.isLoading,
                 ) {
@@ -200,4 +198,57 @@ private fun LoginField(
                 unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
             ),
     )
+}
+
+@Composable
+private fun LoginActionButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    content: @Composable () -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .scale(if (focused && enabled) 1.02f else 1f)
+                .clip(RoundedCornerShape(20.dp))
+                .background(
+                    if (enabled) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.46f)
+                    },
+                )
+                .border(
+                    width = if (focused && enabled) 3.dp else 1.dp,
+                    color =
+                        if (focused && enabled) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else if (enabled) {
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.88f)
+                        } else {
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
+                        },
+                    shape = RoundedCornerShape(20.dp),
+                )
+                .onFocusChanged { focused = it.hasFocus }
+                .focusable(enabled = enabled)
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(horizontal = 18.dp, vertical = 14.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        androidx.compose.runtime.CompositionLocalProvider(
+            androidx.compose.material3.LocalContentColor provides
+                if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                androidx.compose.material3.ProvideTextStyle(
+                    value = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    content = content,
+                )
+            }
+        }
+    }
 }

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseFocusCard.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseFocusCard.kt
@@ -29,8 +29,8 @@ internal fun FocusScaleCard(
     Box(
         modifier =
             modifier
-                .scale(if (focused) 1.04f else 1f)
-                .clip(RoundedCornerShape(24.dp))
+                .scale(if (focused) 1.02f else 1f)
+                .clip(RoundedCornerShape(20.dp))
                 .background(
                     if (focused) {
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
@@ -46,12 +46,12 @@ internal fun FocusScaleCard(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
                         },
-                    shape = RoundedCornerShape(24.dp),
+                    shape = RoundedCornerShape(20.dp),
                 )
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable()
                 .clickable(onClick = onClick)
-                .padding(16.dp),
+                .padding(14.dp),
     ) {
         content()
     }

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
@@ -3,6 +3,9 @@
 package com.tuneflow.feature.browse
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,13 +39,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.tv.material3.Button
 import coil.compose.AsyncImage
 import com.tuneflow.core.network.AlbumSummary
 import com.tuneflow.core.network.PlaylistSummary
@@ -67,16 +71,13 @@ fun AlbumsScreen(
 
         else -> {
             Column(modifier = modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(18.dp)) {
-                SectionTitle(
-                    title = "Albums",
-                    subtitle = "Larger artwork and calmer spacing for distance-friendly browsing.",
-                )
+                SectionTitle(title = "Albums")
                 LazyVerticalGrid(
-                    columns = GridCells.Adaptive(minSize = 240.dp),
+                    columns = GridCells.Adaptive(minSize = 220.dp),
                     modifier = Modifier.fillMaxSize(),
-                    horizontalArrangement = Arrangement.spacedBy(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(24.dp),
-                    contentPadding = PaddingValues(bottom = 56.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(18.dp),
+                    contentPadding = PaddingValues(bottom = 48.dp),
                 ) {
                     items(state.items, key = { it.id }) { album ->
                         PremiumAlbumCard(album = album, onClick = { onAlbumSelected(album.id) })
@@ -91,8 +92,8 @@ fun AlbumsScreen(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .height(280.dp)
-                                        .clip(RoundedCornerShape(24.dp))
+                                        .height(240.dp)
+                                        .clip(RoundedCornerShape(20.dp))
                                         .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.72f)),
                                 contentAlignment = Alignment.Center,
                             ) {
@@ -128,16 +129,16 @@ fun AlbumDetailScreen(
             val album = state.album!!
             Row(
                 modifier = modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.spacedBy(26.dp),
+                horizontalArrangement = Arrangement.spacedBy(22.dp),
             ) {
                 Box(
                     modifier =
                         Modifier
-                            .width(360.dp)
+                            .width(320.dp)
                             .fillMaxSize()
-                            .clip(RoundedCornerShape(28.dp))
+                            .clip(RoundedCornerShape(24.dp))
                             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f))
-                            .padding(22.dp),
+                            .padding(18.dp),
                 ) {
                     if (album.artUrl != null) {
                         AsyncImage(
@@ -147,8 +148,8 @@ fun AlbumDetailScreen(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .height(316.dp)
-                                    .clip(RoundedCornerShape(26.dp))
+                                    .height(276.dp)
+                                    .clip(RoundedCornerShape(22.dp))
                                     .align(Alignment.TopCenter),
                         )
                     }
@@ -160,7 +161,7 @@ fun AlbumDetailScreen(
                 ) {
                     Text(
                         text = album.title,
-                        style = MaterialTheme.typography.displaySmall,
+                        style = MaterialTheme.typography.headlineLarge,
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
@@ -170,7 +171,7 @@ fun AlbumDetailScreen(
                         style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    Button(
+                    BrowseActionButton(
                         onClick = { onPlayAlbum(album.tracks, 0) },
                         modifier = Modifier.focusRequester(playButtonFocusRequester),
                     ) {
@@ -258,7 +259,6 @@ fun ArtistDetailScreen(
 
                 SectionTitle(
                     title = "Albums",
-                    subtitle = "Jump from artist overview into album playback quickly.",
                 )
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                     items(artist.albums, key = { it.id }) { album ->
@@ -294,14 +294,11 @@ fun PlaylistsScreen(
         Column(
             modifier =
                 Modifier
-                    .width(380.dp)
+                    .width(348.dp)
                     .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            SectionTitle(
-                title = "Playlists",
-                subtitle = "Curated listening paths with clearer focus and lower density.",
-            )
+            SectionTitle(title = "Playlists")
 
             if (state.isLoading && state.playlists.isEmpty()) {
                 LoadingState(label = "Loading playlists...")
@@ -322,9 +319,9 @@ fun PlaylistsScreen(
                 Modifier
                     .weight(1f)
                     .fillMaxSize()
-                    .clip(RoundedCornerShape(28.dp))
+                    .clip(RoundedCornerShape(24.dp))
                     .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f))
-                    .padding(22.dp),
+                    .padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             when {
@@ -342,10 +339,10 @@ fun PlaylistsScreen(
                     val selected = state.selected!!
                     Text(
                         text = selected.name,
-                        style = MaterialTheme.typography.displaySmall,
+                        style = MaterialTheme.typography.headlineLarge,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
-                    Button(onClick = { onPlayTracks(selected.tracks, 0) }) {
+                    BrowseActionButton(onClick = { onPlayTracks(selected.tracks, 0) }) {
                         Text("Play Playlist")
                     }
                     LazyColumn(
@@ -391,10 +388,7 @@ fun SearchScreen(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {
-        SectionTitle(
-            title = "Search",
-            subtitle = "Grouped results and calmer layouts to reduce typing fatigue on TV.",
-        )
+        SectionTitle(title = "Search")
 
         OutlinedTextField(
             value = query,
@@ -435,7 +429,7 @@ fun SearchScreen(
             contentPadding = PaddingValues(bottom = 48.dp),
         ) {
             if (query.isBlank() && state.recentQueries.isNotEmpty()) {
-                item { SectionTitle(title = "Recent Queries", subtitle = "Jump back into common searches with fewer clicks") }
+                item { SectionTitle(title = "Recent Queries") }
                 item {
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
                         items(state.recentQueries, key = { it }) { recentQuery ->
@@ -449,7 +443,7 @@ fun SearchScreen(
             }
 
             if (query.isNotBlank() && state.suggestions.isNotEmpty()) {
-                item { SectionTitle(title = "Suggestions", subtitle = "Fast fills from live Navidrome results") }
+                item { SectionTitle(title = "Suggestions") }
                 item {
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
                         items(state.suggestions, key = { it }) { suggestion ->
@@ -463,7 +457,7 @@ fun SearchScreen(
             }
 
             if (state.result.artists.isNotEmpty()) {
-                item { SectionTitle(title = "Artists", subtitle = "Open the artist surface directly from search") }
+                item { SectionTitle(title = "Artists") }
                 item {
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
                         items(state.result.artists, key = { it.id }) { artist ->
@@ -477,7 +471,7 @@ fun SearchScreen(
             }
 
             if (state.result.albums.isNotEmpty()) {
-                item { SectionTitle(title = "Albums", subtitle = "Artwork-forward album matches") }
+                item { SectionTitle(title = "Albums") }
                 item {
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
                         items(state.result.albums, key = { it.id }) { album ->
@@ -488,7 +482,7 @@ fun SearchScreen(
             }
 
             if (state.result.tracks.isNotEmpty()) {
-                item { SectionTitle(title = "Tracks", subtitle = "Start playback directly from search results") }
+                item { SectionTitle(title = "Tracks") }
                 items(state.result.tracks, key = { it.id }) { track ->
                     PremiumListRow(
                         title = track.title,
@@ -521,8 +515,8 @@ private fun PremiumPlaylistRow(
                 label = playlist.name,
                 modifier =
                     Modifier
-                        .size(72.dp)
-                        .clip(RoundedCornerShape(16.dp)),
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(14.dp)),
             )
             Column(
                 modifier = Modifier.weight(1f),
@@ -551,7 +545,7 @@ private fun PremiumAlbumCard(
     onClick: () -> Unit,
 ) {
     FocusScaleCard(
-        modifier = Modifier.width(244.dp),
+        modifier = Modifier.width(220.dp),
         onClick = onClick,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -559,8 +553,8 @@ private fun PremiumAlbumCard(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .height(244.dp)
-                        .clip(RoundedCornerShape(22.dp))
+                        .height(220.dp)
+                        .clip(RoundedCornerShape(20.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.82f)),
             ) {
                 if (album.artUrl != null) {
@@ -652,7 +646,7 @@ private fun PremiumChip(
     FocusScaleCard(
         modifier =
             Modifier
-                .width(220.dp),
+                .width(196.dp),
         onClick = onClick,
     ) {
         Text(
@@ -719,21 +713,51 @@ private fun PlaylistArtworkGrid(
 }
 
 @Composable
-private fun SectionTitle(
-    title: String,
-    subtitle: String,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+private fun SectionTitle(title: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
             text = title,
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        Text(
-            text = subtitle,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    }
+}
+
+@Composable
+private fun BrowseActionButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+
+    Box(
+        modifier =
+            modifier
+                .scale(if (focused) 1.02f else 1f)
+                .clip(RoundedCornerShape(20.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.86f))
+                .border(
+                    width = if (focused) 3.dp else 1.dp,
+                    color =
+                        if (focused) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
+                        },
+                    shape = RoundedCornerShape(20.dp),
+                )
+                .onFocusChanged { focused = it.hasFocus }
+                .focusable()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 18.dp, vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        androidx.compose.runtime.CompositionLocalProvider(
+            androidx.compose.material3.LocalContentColor provides MaterialTheme.colorScheme.onSurface,
+        ) {
+            content()
+        }
     }
 }
 

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -1,6 +1,5 @@
 package com.tuneflow.feature.playback
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,8 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -29,19 +27,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
-import com.tuneflow.feature.playback.R as PlaybackR
+import android.view.KeyEvent as AndroidKeyEvent
 
 @Composable
 fun NowPlayingScreen(
@@ -62,27 +58,7 @@ fun NowPlayingScreen(
         modifier =
             modifier
                 .fillMaxSize()
-                .onKeyEvent {
-                    if (it.type != KeyEventType.KeyDown) return@onKeyEvent false
-                    when (it.key) {
-                        Key.DirectionCenter -> {
-                            viewModel.togglePlayPause()
-                            true
-                        }
-
-                        Key.DirectionRight -> {
-                            viewModel.next()
-                            true
-                        }
-
-                        Key.DirectionLeft -> {
-                            viewModel.previous()
-                            true
-                        }
-
-                        else -> false
-                    }
-                },
+                .onPreviewKeyEvent { event -> handlePlaybackKey(event, viewModel) },
     ) {
         if (item?.artUrl != null) {
             AsyncImage(
@@ -109,10 +85,12 @@ fun NowPlayingScreen(
             Box(
                 modifier =
                     Modifier
-                        .size(360.dp)
+                        .padding(horizontal = 12.dp)
+                        .height(320.dp)
+                        .fillMaxWidth(0.34f)
                         .background(
                             color = MaterialTheme.colorScheme.surface.copy(alpha = 0.82f),
-                            shape = RoundedCornerShape(32.dp),
+                            shape = RoundedCornerShape(28.dp),
                         ),
                 contentAlignment = Alignment.Center,
             ) {
@@ -139,7 +117,7 @@ fun NowPlayingScreen(
 
             Text(
                 text = item?.title ?: "Nothing playing",
-                style = MaterialTheme.typography.displaySmall,
+                style = MaterialTheme.typography.headlineLarge,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -188,24 +166,20 @@ fun NowPlayingScreen(
                 }
             }
 
-            Spacer(Modifier.height(28.dp))
+            Spacer(Modifier.height(24.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(22.dp)) {
-                PlaybackIconButton(
-                    iconResId = PlaybackR.drawable.ic_skip_button,
-                    contentDescription = "Previous",
-                    mirrored = true,
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                PlaybackTextButton(
+                    label = "Previous",
                     onClick = viewModel::previous,
                 )
-                PlaybackIconButton(
-                    iconResId = if (state.isPlaying) PlaybackR.drawable.ic_pause_button else PlaybackR.drawable.ic_play_button,
-                    contentDescription = if (state.isPlaying) "Pause" else "Play",
+                PlaybackTextButton(
+                    label = if (state.isPlaying) "Pause" else "Play",
                     accent = true,
                     onClick = viewModel::togglePlayPause,
                 )
-                PlaybackIconButton(
-                    iconResId = PlaybackR.drawable.ic_skip_button,
-                    contentDescription = "Next",
+                PlaybackTextButton(
+                    label = "Next",
                     onClick = viewModel::next,
                 )
             }
@@ -213,11 +187,52 @@ fun NowPlayingScreen(
     }
 }
 
+private fun handlePlaybackKey(
+    event: androidx.compose.ui.input.key.KeyEvent,
+    viewModel: PlaybackViewModel,
+): Boolean {
+    if (event.type != KeyEventType.KeyDown) return false
+
+    return when (event.nativeKeyEvent.keyCode) {
+        AndroidKeyEvent.KEYCODE_DPAD_CENTER,
+        AndroidKeyEvent.KEYCODE_ENTER,
+        AndroidKeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+        -> {
+            viewModel.togglePlayPause()
+            true
+        }
+
+        AndroidKeyEvent.KEYCODE_MEDIA_PLAY -> {
+            viewModel.play()
+            true
+        }
+
+        AndroidKeyEvent.KEYCODE_MEDIA_PAUSE -> {
+            viewModel.pause()
+            true
+        }
+
+        AndroidKeyEvent.KEYCODE_DPAD_RIGHT,
+        AndroidKeyEvent.KEYCODE_MEDIA_NEXT,
+        -> {
+            viewModel.next()
+            true
+        }
+
+        AndroidKeyEvent.KEYCODE_DPAD_LEFT,
+        AndroidKeyEvent.KEYCODE_MEDIA_PREVIOUS,
+        -> {
+            viewModel.previous()
+            true
+        }
+
+        else -> false
+    }
+}
+
 @Composable
-private fun PlaybackIconButton(
-    iconResId: Int,
-    contentDescription: String,
-    mirrored: Boolean = false,
+private fun PlaybackTextButton(
+    label: String,
     accent: Boolean = false,
     onClick: () -> Unit,
 ) {
@@ -226,13 +241,13 @@ private fun PlaybackIconButton(
     Box(
         modifier =
             Modifier
-                .scale(if (focused) 1.06f else 1f)
-                .clip(CircleShape)
+                .scale(if (focused) 1.02f else 1f)
+                .clip(RoundedCornerShape(24.dp))
                 .background(
                     if (accent) {
-                        MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+                        MaterialTheme.colorScheme.primary
                     } else {
-                        MaterialTheme.colorScheme.surface.copy(alpha = 0.44f)
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.86f)
                     },
                 )
                 .border(
@@ -243,13 +258,19 @@ private fun PlaybackIconButton(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
                         },
-                    shape = CircleShape,
+                    shape = RoundedCornerShape(24.dp),
                 )
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable()
                 .clickable(onClick = onClick)
                 .onKeyEvent {
-                    if (it.type == KeyEventType.KeyDown && it.key == Key.DirectionCenter) {
+                    if (it.type == KeyEventType.KeyDown &&
+                        it.nativeKeyEvent.keyCode in
+                        listOf(
+                            AndroidKeyEvent.KEYCODE_DPAD_CENTER,
+                            AndroidKeyEvent.KEYCODE_ENTER,
+                        )
+                    ) {
                         onClick()
                         true
                     } else {
@@ -258,14 +279,12 @@ private fun PlaybackIconButton(
                 },
         contentAlignment = Alignment.Center,
     ) {
-        Image(
-            painter = painterResource(id = iconResId),
-            contentDescription = contentDescription,
-            modifier =
-                Modifier
-                    .size(if (accent) 132.dp else 114.dp)
-                    .graphicsLayer { scaleX = if (mirrored) -1f else 1f },
-            contentScale = ContentScale.Fit,
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = if (accent) 34.dp else 24.dp, vertical = 16.dp),
+            color = if (accent) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
         )
     }
 }

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/PlaybackViewModel.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/PlaybackViewModel.kt
@@ -64,6 +64,10 @@ class PlaybackViewModel(
         }
     }
 
+    fun play() = playerManager.play()
+
+    fun pause() = playerManager.pause()
+
     fun next() = playerManager.next()
 
     fun previous() = playerManager.previous()


### PR DESCRIPTION
## Summary
- tone down oversized home, browse, and playback scaling
- remove redundant section helper text and improve focused button readability
- replace direct logout rail item with username account panel and app version
- rebalance login screen and map remote media play/pause controls

## Verification
- ./gradlew :app:assembleDebug
- ./gradlew :app:lintDebug
- ./gradlew :app:detekt
- ./gradlew :app:ktlintCheck
- ./gradlew :feature:auth:detekt :feature:auth:ktlintCheck
- ./gradlew :feature:browse:detekt :feature:browse:ktlintCheck
- ./gradlew :feature:playback:detekt :feature:playback:ktlintCheck