### PR TITLE
fix(tv): improve focus navigation

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/HomeScreen.kt
+++ b/app/src/main/java/com/tuneflow/tv/HomeScreen.kt
@@ -74,6 +74,9 @@ fun HomeScreen(
         verticalArrangement = Arrangement.spacedBy(22.dp),
     ) {
         item {
+            ScreenInitialFocusAnchor()
+        }
+        item {
             HomeHero(
                 playbackQueue = playbackQueue,
                 onPrimaryAction = if (playbackQueue.items.isNotEmpty()) onOpenNowPlaying else onOpenSearch,
@@ -177,11 +180,6 @@ private fun HomeHero(
     onSecondaryAction: () -> Unit,
 ) {
     val currentItem = playbackQueue.currentItem
-    val primaryFocusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(currentItem?.id) {
-        primaryFocusRequester.requestFocus()
-    }
 
     Box(
         modifier =
@@ -246,7 +244,6 @@ private fun HomeHero(
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                     HeroActionButton(
                         label = if (currentItem != null) "Resume Playback" else "Start Searching",
-                        focusedRequester = primaryFocusRequester,
                         accent = true,
                         onClick = onPrimaryAction,
                     )
@@ -289,7 +286,6 @@ private fun HomeHero(
 @Composable
 private fun HeroActionButton(
     label: String,
-    focusedRequester: FocusRequester? = null,
     accent: Boolean = false,
     onClick: () -> Unit,
 ) {
@@ -299,7 +295,6 @@ private fun HeroActionButton(
     Box(
         modifier =
             Modifier
-                .then(if (focusedRequester != null) Modifier.focusRequester(focusedRequester) else Modifier)
                 .scale(if (focused) 1.02f else 1f)
                 .clip(shape)
                 .background(
@@ -339,6 +334,23 @@ private fun HeroActionButton(
             fontWeight = FontWeight.Bold,
         )
     }
+}
+
+@Composable
+private fun ScreenInitialFocusAnchor() {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Box(
+        modifier =
+            Modifier
+                .size(1.dp)
+                .focusRequester(focusRequester)
+                .focusable(),
+    )
 }
 
 @Composable

--- a/feature/auth/src/main/java/com/tuneflow/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/tuneflow/feature/auth/LoginScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,14 +31,27 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+private enum class LoginFieldKey { ServerUrl, Username, Password }
 
 @Composable
 fun LoginScreen(
@@ -47,6 +61,7 @@ fun LoginScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var editingField by remember { mutableStateOf<LoginFieldKey?>(null) }
 
     Box(
         modifier =
@@ -122,11 +137,17 @@ fun LoginScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
 
+                ScreenInitialFocusAnchor()
+
                 LoginField(
                     value = state.serverUrl,
                     onValueChange = viewModel::updateServerUrl,
                     label = "Navidrome URL",
                     placeholder = "http://192.168.1.10:4533",
+                    editing = editingField == LoginFieldKey.ServerUrl,
+                    onEditingChange = { isEditing ->
+                        editingField = if (isEditing) LoginFieldKey.ServerUrl else null
+                    },
                 )
 
                 LoginField(
@@ -134,6 +155,10 @@ fun LoginScreen(
                     onValueChange = viewModel::updateUsername,
                     label = "Username",
                     placeholder = "Your Navidrome user",
+                    editing = editingField == LoginFieldKey.Username,
+                    onEditingChange = { isEditing ->
+                        editingField = if (isEditing) LoginFieldKey.Username else null
+                    },
                 )
 
                 LoginField(
@@ -143,6 +168,10 @@ fun LoginScreen(
                     placeholder = "Password",
                     keyboardType = KeyboardType.Password,
                     obscure = true,
+                    editing = editingField == LoginFieldKey.Password,
+                    onEditingChange = { isEditing ->
+                        editingField = if (isEditing) LoginFieldKey.Password else null
+                    },
                 )
 
                 if (state.error != null) {
@@ -172,33 +201,190 @@ private fun LoginField(
     placeholder: String,
     keyboardType: KeyboardType = KeyboardType.Text,
     obscure: Boolean = false,
+    editing: Boolean,
+    onEditingChange: (Boolean) -> Unit,
+) {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val editFocusRequester = remember { FocusRequester() }
+    val displayFocusRequester = remember { FocusRequester() }
+    var focused by remember { mutableStateOf(false) }
+    var restoreDisplayFocus by remember { mutableStateOf(false) }
+
+    fun stopEditing() {
+        keyboardController?.hide()
+        focusManager.clearFocus(force = true)
+        restoreDisplayFocus = true
+        onEditingChange(false)
+    }
+
+    LaunchedEffect(editing, restoreDisplayFocus) {
+        when {
+            editing -> {
+                editFocusRequester.requestFocus()
+                keyboardController?.show()
+            }
+            restoreDisplayFocus -> {
+                displayFocusRequester.requestFocus()
+                restoreDisplayFocus = false
+            }
+        }
+    }
+
+    if (editing) {
+        EditingLoginField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            placeholder = { Text(placeholder) },
+            visualTransformation = if (obscure) PasswordVisualTransformation() else VisualTransformation.None,
+            keyboardType = keyboardType,
+            focusRequester = editFocusRequester,
+            onBack = ::stopEditing,
+        )
+    } else {
+        DisplayLoginField(
+            value = value,
+            label = label,
+            placeholder = placeholder,
+            obscure = obscure,
+            focused = focused,
+            focusRequester = displayFocusRequester,
+            onFocusedChange = { focused = it },
+            onClick = { onEditingChange(true) },
+        )
+    }
+}
+
+@Composable
+private fun EditingLoginField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: @Composable () -> Unit,
+    placeholder: @Composable () -> Unit,
+    visualTransformation: VisualTransformation,
+    keyboardType: KeyboardType,
+    focusRequester: FocusRequester,
+    onBack: () -> Unit,
 ) {
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        label = { Text(label) },
-        placeholder = { Text(placeholder) },
+        label = label,
+        placeholder = placeholder,
         singleLine = true,
         textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-        visualTransformation = if (obscure) PasswordVisualTransformation() else androidx.compose.ui.text.input.VisualTransformation.None,
-        modifier = Modifier.fillMaxWidth(),
-        colors =
-            OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = MaterialTheme.colorScheme.primary,
-                unfocusedBorderColor = MaterialTheme.colorScheme.outline,
-                focusedLabelColor = MaterialTheme.colorScheme.primary,
-                unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                cursorColor = MaterialTheme.colorScheme.primary,
-                focusedTextColor = MaterialTheme.colorScheme.onSurface,
-                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-                focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.58f),
-                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
-                focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ),
+        visualTransformation = visualTransformation,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .onPreviewKeyEvent {
+                    if (it.type == KeyEventType.KeyDown && it.key == Key.Back) {
+                        onBack()
+                        true
+                    } else {
+                        false
+                    }
+                },
+        colors = loginFieldColors(),
     )
 }
+
+@Composable
+private fun DisplayLoginField(
+    value: String,
+    label: String,
+    placeholder: String,
+    obscure: Boolean,
+    focused: Boolean,
+    focusRequester: FocusRequester,
+    onFocusedChange: (Boolean) -> Unit,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .scale(if (focused) 1.01f else 1f)
+                .clip(RoundedCornerShape(18.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f))
+                .border(
+                    width = if (focused) 2.dp else 1.dp,
+                    color =
+                        if (focused) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        },
+                    shape = RoundedCornerShape(18.dp),
+                )
+                .onFocusChanged { onFocusedChange(it.hasFocus) }
+                .focusable()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 18.dp, vertical = 14.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = if (focused) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text =
+                    when {
+                        value.isNotBlank() && obscure -> "•".repeat(value.length.coerceAtMost(16))
+                        value.isNotBlank() -> value
+                        else -> placeholder
+                    },
+                style = MaterialTheme.typography.bodyLarge,
+                color =
+                    if (value.isNotBlank()) {
+                        MaterialTheme.colorScheme.onSurface
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScreenInitialFocusAnchor() {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Box(
+        modifier =
+            Modifier
+                .size(1.dp)
+                .focusRequester(focusRequester)
+                .focusable(),
+    )
+}
+
+@Composable
+private fun loginFieldColors() =
+    OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = MaterialTheme.colorScheme.primary,
+        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+        focusedLabelColor = MaterialTheme.colorScheme.primary,
+        unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        cursorColor = MaterialTheme.colorScheme.primary,
+        focusedTextColor = MaterialTheme.colorScheme.onSurface,
+        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.58f),
+        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
+        focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 
 @Composable
 private fun LoginActionButton(

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -43,7 +44,15 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -71,6 +80,7 @@ fun AlbumsScreen(
 
         else -> {
             Column(modifier = modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(18.dp)) {
+                ScreenInitialFocusAnchor()
                 SectionTitle(title = "Albums")
                 LazyVerticalGrid(
                     columns = GridCells.Adaptive(minSize = 220.dp),
@@ -115,7 +125,6 @@ fun AlbumDetailScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    val playButtonFocusRequester = remember { FocusRequester() }
 
     LaunchedEffect(albumId) {
         viewModel.load(albumId)
@@ -159,6 +168,7 @@ fun AlbumDetailScreen(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(18.dp),
                 ) {
+                    ScreenInitialFocusAnchor()
                     Text(
                         text = album.title,
                         style = MaterialTheme.typography.headlineLarge,
@@ -173,12 +183,8 @@ fun AlbumDetailScreen(
                     )
                     BrowseActionButton(
                         onClick = { onPlayAlbum(album.tracks, 0) },
-                        modifier = Modifier.focusRequester(playButtonFocusRequester),
                     ) {
                         Text("Play Album")
-                    }
-                    LaunchedEffect(album.id) {
-                        playButtonFocusRequester.requestFocus()
                     }
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
@@ -223,6 +229,7 @@ fun ArtistDetailScreen(
                 modifier = modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(22.dp),
             ) {
+                ScreenInitialFocusAnchor()
                 Box(
                     modifier =
                         Modifier
@@ -298,6 +305,7 @@ fun PlaylistsScreen(
                     .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            ScreenInitialFocusAnchor()
             SectionTitle(title = "Playlists")
 
             if (state.isLoading && state.playlists.isEmpty()) {
@@ -379,6 +387,7 @@ fun SearchScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var query by remember { mutableStateOf(state.query) }
+    var editingQuery by remember { mutableStateOf(false) }
 
     LaunchedEffect(state.query) {
         query = state.query
@@ -388,9 +397,10 @@ fun SearchScreen(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(18.dp),
     ) {
+        ScreenInitialFocusAnchor()
         SectionTitle(title = "Search")
 
-        OutlinedTextField(
+        SearchField(
             value = query,
             onValueChange = {
                 query = it
@@ -398,19 +408,8 @@ fun SearchScreen(
             },
             label = { Text("Search your library") },
             placeholder = { Text("Artist, album, or track") },
-            modifier = Modifier.fillMaxWidth(),
-            textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
-            colors =
-                OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outline,
-                    focusedLabelColor = MaterialTheme.colorScheme.primary,
-                    unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
-                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-                    focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.58f),
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
-                ),
+            editing = editingQuery,
+            onEditingChange = { editingQuery = it },
         )
 
         if (state.isLoading) {
@@ -537,6 +536,139 @@ private fun PremiumPlaylistRow(
             }
         }
     }
+}
+
+@Composable
+private fun SearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: @Composable () -> Unit,
+    placeholder: @Composable () -> Unit,
+    editing: Boolean,
+    onEditingChange: (Boolean) -> Unit,
+) {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val editFocusRequester = remember { FocusRequester() }
+    val displayFocusRequester = remember { FocusRequester() }
+    var focused by remember { mutableStateOf(false) }
+    var restoreDisplayFocus by remember { mutableStateOf(false) }
+
+    fun stopEditing() {
+        keyboardController?.hide()
+        focusManager.clearFocus(force = true)
+        restoreDisplayFocus = true
+        onEditingChange(false)
+    }
+
+    LaunchedEffect(editing, restoreDisplayFocus) {
+        when {
+            editing -> {
+                editFocusRequester.requestFocus()
+                keyboardController?.show()
+            }
+            restoreDisplayFocus -> {
+                displayFocusRequester.requestFocus()
+                restoreDisplayFocus = false
+            }
+        }
+    }
+
+    if (editing) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = label,
+            placeholder = placeholder,
+            singleLine = true,
+            textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+            keyboardOptions = KeyboardOptions.Default,
+            visualTransformation = VisualTransformation.None,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .focusRequester(editFocusRequester)
+                    .onPreviewKeyEvent {
+                        if (it.type == KeyEventType.KeyDown && it.key == Key.Back) {
+                            stopEditing()
+                            true
+                        } else {
+                            false
+                        }
+                    },
+            colors = searchFieldColors(),
+        )
+    } else {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .focusRequester(displayFocusRequester)
+                    .scale(if (focused) 1.01f else 1f)
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f))
+                    .border(
+                        width = if (focused) 2.dp else 1.dp,
+                        color =
+                            if (focused) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outline
+                            },
+                        shape = RoundedCornerShape(18.dp),
+                    )
+                    .onFocusChanged { focused = it.hasFocus }
+                    .focusable()
+                    .clickable { onEditingChange(true) }
+                    .padding(horizontal = 18.dp, vertical = 14.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Box { label() }
+                Text(
+                    text = if (value.isNotBlank()) value else "Artist, album, or track",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color =
+                        if (value.isNotBlank()) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun searchFieldColors() =
+    OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = MaterialTheme.colorScheme.primary,
+        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+        focusedLabelColor = MaterialTheme.colorScheme.primary,
+        unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        focusedTextColor = MaterialTheme.colorScheme.onSurface,
+        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.58f),
+        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
+    )
+
+@Composable
+private fun ScreenInitialFocusAnchor() {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Box(
+        modifier =
+            Modifier
+                .size(1.dp)
+                .focusRequester(focusRequester)
+                .focusable(),
+    )
 }
 
 @Composable

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -13,11 +13,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,6 +28,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onKeyEvent
@@ -82,6 +86,7 @@ fun NowPlayingScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
+            ScreenInitialFocusAnchor()
             Box(
                 modifier =
                     Modifier
@@ -287,6 +292,23 @@ private fun PlaybackTextButton(
             fontWeight = FontWeight.Bold,
         )
     }
+}
+
+@Composable
+private fun ScreenInitialFocusAnchor() {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Box(
+        modifier =
+            Modifier
+                .size(1.dp)
+                .focusRequester(focusRequester)
+                .focusable(),
+    )
 }
 
 private fun formatTime(ms: Long): String {


### PR DESCRIPTION
## Summary
- fix TV login navigation so fields are focused first and only enter edit mode on select
- let back exit keyboard/edit mode and restore focus to the active field
- remove auto-focus jumps on home, browse, and now playing so screens open without visible preselection

## Verification
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:assembleDebug
- ./gradlew :app:detekt :feature:auth:detekt :feature:browse:detekt :feature:playback:detekt
- ./gradlew :app:ktlintCheck :feature:auth:ktlintCheck :feature:browse:ktlintCheck :feature:playback:ktlintCheck
