### PR TITLE
feat(tv): add stream mode toggle

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -45,8 +46,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.tuneflow.core.network.PlaybackPreferencesStore
 import com.tuneflow.core.network.SearchHistoryStore
 import com.tuneflow.core.network.SessionStore
+import com.tuneflow.core.network.TrackStreamOptions
 import com.tuneflow.core.player.PlaybackQueue
 import com.tuneflow.core.player.PlayerGraph
 import com.tuneflow.core.player.QueueItem
@@ -68,6 +71,7 @@ class MainActivity : ComponentActivity() {
 
         val sessionStore = SessionStore(applicationContext)
         val searchHistoryStore = SearchHistoryStore(applicationContext)
+        val playbackPreferencesStore = PlaybackPreferencesStore(applicationContext)
         val authRepository = AuthRepository(sessionStore)
         val browseRepository = BrowseRepository(sessionStore)
         val playerManager = PlayerGraph.get(applicationContext)
@@ -92,6 +96,7 @@ class MainActivity : ComponentActivity() {
                         browseRepository = browseRepository,
                         playerManager = playerManager,
                         sessionStore = sessionStore,
+                        playbackPreferencesStore = playbackPreferencesStore,
                         searchHistoryStore = searchHistoryStore,
                         onLogout = {
                             playerManager.stopAndClear()
@@ -104,14 +109,20 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-private fun com.tuneflow.core.network.TrackSummary.toQueueItem(streamUrl: String): QueueItem {
+private fun com.tuneflow.core.network.TrackSummary.toQueueItem(
+    streamOptions: TrackStreamOptions,
+    preferDirectWithFallback: Boolean,
+): QueueItem {
     return QueueItem(
         id = id,
         title = title,
         artist = artist,
         album = album,
         artUrl = artUrl,
-        streamUrl = streamUrl,
+        streamUrl = if (preferDirectWithFallback) streamOptions.directUrl else streamOptions.fallbackMp3Url,
+        fallbackStreamUrl = if (preferDirectWithFallback) streamOptions.fallbackMp3Url else null,
+        streamFormatLabel = if (preferDirectWithFallback) "FLAC" else "MP3",
+        streamBitrateLabel = if (preferDirectWithFallback) "Original" else "Max",
         durationMs = durationSec * 1000L,
     )
 }
@@ -125,6 +136,7 @@ private fun TuneFlowShell(
     browseRepository: BrowseRepository,
     playerManager: com.tuneflow.core.player.TvPlayerManager,
     sessionStore: SessionStore,
+    playbackPreferencesStore: PlaybackPreferencesStore,
     searchHistoryStore: SearchHistoryStore,
     onLogout: () -> Unit,
 ) {
@@ -142,6 +154,7 @@ private fun TuneFlowShell(
     val playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel = viewModel(factory = PlaybackViewModelFactory(playerManager))
     val playbackState by playbackViewModel.uiState.collectAsStateWithLifecycle()
     val session by sessionStore.sessionFlow.collectAsStateWithLifecycle(initialValue = null)
+    val preferDirectWithFallback by playbackPreferencesStore.preferDirectWithFallbackFlow.collectAsStateWithLifecycle(initialValue = true)
 
     var currentSection by rememberSaveable { mutableStateOf(NavSection.Home) }
     var selectedAlbumId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -200,7 +213,8 @@ private fun TuneFlowShell(
             val queue =
                 tracks.map { track ->
                     track.toQueueItem(
-                        streamUrl = browseRepository.streamUrl(track.id),
+                        streamOptions = browseRepository.streamOptions(track.id),
+                        preferDirectWithFallback = preferDirectWithFallback,
                     )
                 }
             playerManager.playQueue(queue, index)
@@ -262,6 +276,12 @@ private fun TuneFlowShell(
                 onNowPlaying = ::openNowPlaying,
                 isNowPlayingActive = showNowPlaying,
                 username = session?.username.orEmpty(),
+                preferDirectWithFallback = preferDirectWithFallback,
+                onTogglePreferDirectWithFallback = {
+                    scope.launch {
+                        playbackPreferencesStore.setPreferDirectWithFallback(it)
+                    }
+                },
                 onLogout = onLogout,
             )
 
@@ -448,6 +468,8 @@ private fun NavRail(
     onNowPlaying: () -> Unit,
     isNowPlayingActive: Boolean,
     username: String,
+    preferDirectWithFallback: Boolean,
+    onTogglePreferDirectWithFallback: (Boolean) -> Unit,
     onLogout: () -> Unit,
 ) {
     var accountExpanded by rememberSaveable { mutableStateOf(false) }
@@ -539,6 +561,8 @@ private fun NavRail(
 
         AccountRailSection(
             username = username.ifBlank { "Account" },
+            preferDirectWithFallback = preferDirectWithFallback,
+            onTogglePreferDirectWithFallback = onTogglePreferDirectWithFallback,
             expanded = accountExpanded,
             onToggleExpanded = { accountExpanded = !accountExpanded },
             onExpand = { accountExpanded = true },
@@ -601,6 +625,8 @@ private fun RailItem(
 @Composable
 private fun AccountRailSection(
     username: String,
+    preferDirectWithFallback: Boolean,
+    onTogglePreferDirectWithFallback: (Boolean) -> Unit,
     expanded: Boolean,
     onToggleExpanded: () -> Unit,
     onExpand: () -> Unit,
@@ -673,6 +699,12 @@ private fun AccountRailSection(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                AccountToggleRow(
+                    title = "FLAC Fallback",
+                    subtitle = if (preferDirectWithFallback) "Try FLAC, fall back to MP3" else "Always use MP3 max bitrate",
+                    checked = preferDirectWithFallback,
+                    onToggle = onTogglePreferDirectWithFallback,
+                )
                 RailItem(
                     label = "Logout",
                     selected = false,
@@ -680,5 +712,57 @@ private fun AccountRailSection(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun AccountToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onToggle: (Boolean) -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+
+    Row(
+        modifier =
+            Modifier
+                .width(154.dp)
+                .scale(if (focused) 1.01f else 1f)
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.70f))
+                .border(
+                    width = if (focused) 2.dp else 1.dp,
+                    color =
+                        if (focused) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.16f)
+                        },
+                    shape = RoundedCornerShape(16.dp),
+                )
+                .onFocusChanged { focused = it.hasFocus }
+                .focusable()
+                .clickable { onToggle(!checked) }
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = null,
+        )
     }
 }

--- a/core/network/src/main/java/com/tuneflow/core/network/NavidromeClient.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NavidromeClient.kt
@@ -177,9 +177,15 @@ open class NavidromeClient(private val session: SessionData) {
         }
     }
 
-    open fun streamUrl(trackId: String): String {
-        return "${session.serverUrl}/rest/stream.view" +
-            "?id=$trackId&u=${session.username}&t=${session.token}&s=${session.salt}&v=1.16.1&c=TuneFlow&f=json"
+    open fun streamOptions(trackId: String): TrackStreamOptions {
+        val base =
+            "${session.serverUrl}/rest/stream.view" +
+                "?id=$trackId&u=${session.username}&t=${session.token}&s=${session.salt}&v=1.16.1&c=TuneFlow&f=json"
+
+        return TrackStreamOptions(
+            directUrl = "$base&format=raw",
+            fallbackMp3Url = "$base&format=mp3&maxBitRate=0",
+        )
     }
 
     private inline fun <T> safeCall(block: () -> NetworkResult<T>): NetworkResult<T> {

--- a/core/network/src/main/java/com/tuneflow/core/network/PlaybackPreferencesStore.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/PlaybackPreferencesStore.kt
@@ -1,0 +1,27 @@
+package com.tuneflow.core.network
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.playbackPreferencesDataStore by preferencesDataStore(name = "tuneflow_playback_preferences")
+
+class PlaybackPreferencesStore(private val context: Context) {
+    private object Keys {
+        val preferDirectWithFallback = booleanPreferencesKey("prefer_direct_with_fallback")
+    }
+
+    val preferDirectWithFallbackFlow: Flow<Boolean> =
+        context.playbackPreferencesDataStore.data.map { preferences ->
+            preferences[Keys.preferDirectWithFallback] ?: true
+        }
+
+    suspend fun setPreferDirectWithFallback(enabled: Boolean) {
+        context.playbackPreferencesDataStore.edit { preferences ->
+            preferences[Keys.preferDirectWithFallback] = enabled
+        }
+    }
+}

--- a/core/network/src/main/java/com/tuneflow/core/network/TrackStreamOptions.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/TrackStreamOptions.kt
@@ -1,0 +1,6 @@
+package com.tuneflow.core.network
+
+data class TrackStreamOptions(
+    val directUrl: String,
+    val fallbackMp3Url: String,
+)

--- a/core/network/src/test/java/com/tuneflow/core/network/NavidromeClientTest.kt
+++ b/core/network/src/test/java/com/tuneflow/core/network/NavidromeClientTest.kt
@@ -6,7 +6,7 @@ import java.net.URI
 
 class NavidromeClientTest {
     @Test
-    fun streamUrl_doesNotAddTranscodingParameters() {
+    fun directStreamUrl_requestsRawWithoutBitrateCap() {
         val client =
             NavidromeClient(
                 SessionData(
@@ -17,10 +17,29 @@ class NavidromeClientTest {
                 ),
             )
 
-        val url = client.streamUrl("track-1")
+        val url = client.streamOptions("track-1").directUrl
         val query = URI(url).rawQuery.orEmpty()
 
         assertFalse(query.contains("maxBitRate="))
-        assertFalse(query.contains("format="))
+        org.junit.Assert.assertTrue(query.contains("format=raw"))
+    }
+
+    @Test
+    fun fallbackStreamUrl_requestsMp3WithoutBitrateCap() {
+        val client =
+            NavidromeClient(
+                SessionData(
+                    serverUrl = "https://music.example.com",
+                    username = "demo",
+                    token = "token123",
+                    salt = "salt456",
+                ),
+            )
+
+        val url = client.streamOptions("track-1").fallbackMp3Url
+        val query = URI(url).rawQuery.orEmpty()
+
+        org.junit.Assert.assertTrue(query.contains("maxBitRate=0"))
+        org.junit.Assert.assertTrue(query.contains("format=mp3"))
     }
 }

--- a/core/player/src/main/java/com/tuneflow/core/player/PlaybackQueue.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/PlaybackQueue.kt
@@ -10,6 +10,9 @@ data class QueueItem(
     val album: String,
     val artUrl: String? = null,
     val streamUrl: String,
+    val fallbackStreamUrl: String? = null,
+    val streamFormatLabel: String = "FLAC",
+    val streamBitrateLabel: String = "Original",
     val durationMs: Long = 0L,
 )
 

--- a/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
@@ -296,38 +296,42 @@ class TvPlayerManager(
 
     private fun tryFallbackForCurrentItem(): Boolean {
         val queue = _queue.value
-        val currentItem = queue.currentItem ?: return false
-        val fallbackUrl = currentItem.fallbackStreamUrl ?: return false
-        if (currentItem.streamUrl == fallbackUrl) return false
+        val currentItem = queue.currentItem
+        val fallbackUrl = currentItem?.fallbackStreamUrl
+        val shouldFallback = currentItem != null && !fallbackUrl.isNullOrBlank() && currentItem.streamUrl != fallbackUrl
 
-        val updatedItems =
-            queue.items.mapIndexed { index, item ->
-                if (index == queue.currentIndex) {
-                    item.copy(
-                        streamUrl = fallbackUrl,
-                        fallbackStreamUrl = null,
-                        streamFormatLabel = "MP3",
-                        streamBitrateLabel = "Max",
-                    )
-                } else {
-                    item
+        if (shouldFallback) {
+            val resolvedFallbackUrl = checkNotNull(fallbackUrl)
+            val updatedItems =
+                queue.items.mapIndexed { index, item ->
+                    if (index == queue.currentIndex) {
+                        item.copy(
+                            streamUrl = resolvedFallbackUrl,
+                            fallbackStreamUrl = null,
+                            streamFormatLabel = "MP3",
+                            streamBitrateLabel = "Max",
+                        )
+                    } else {
+                        item
+                    }
                 }
-            }
 
-        val updatedQueue =
-            queue.copy(
-                items = updatedItems,
-                currentPositionMs = player.currentPosition.coerceAtLeast(0L),
-            )
+            val updatedQueue =
+                queue.copy(
+                    items = updatedItems,
+                    currentPositionMs = player.currentPosition.coerceAtLeast(0L),
+                )
 
-        _queue.value = updatedQueue
-        lastError = null
-        player.setMediaItems(updatedItems.map { it.toMediaItem() }, updatedQueue.currentIndex, updatedQueue.currentPositionMs)
-        player.prepare()
-        player.play()
-        scheduleFallbackMonitor()
-        persist()
-        return true
+            _queue.value = updatedQueue
+            lastError = null
+            player.setMediaItems(updatedItems.map { it.toMediaItem() }, updatedQueue.currentIndex, updatedQueue.currentPositionMs)
+            player.prepare()
+            player.play()
+            scheduleFallbackMonitor()
+            persist()
+        }
+
+        return shouldFallback
     }
 
     private fun updateQueueIndex(index: Int) {

--- a/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
@@ -10,7 +10,9 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -27,6 +29,7 @@ class TvPlayerManager(
     private val appContext = context.applicationContext
     private var lastError: PlaybackException? = null
     private var expectedToPlay = false
+    private var fallbackMonitorJob: Job? = null
 
     private val _queue = MutableStateFlow(PlaybackQueue())
     override val queue: StateFlow<PlaybackQueue> = _queue.asStateFlow()
@@ -55,16 +58,33 @@ class TvPlayerManager(
                             _isPlaying.value = isPlaying
                             if (isPlaying) {
                                 lastError = null
+                                cancelFallbackMonitor()
+                            } else if (expectedToPlay) {
+                                scheduleFallbackMonitor()
                             }
                             updatePlaybackStatus()
                         }
 
                         override fun onPlaybackStateChanged(playbackState: Int) {
-                            if (playbackState == Player.STATE_ENDED) {
-                                expectedToPlay = false
-                            }
-                            if (playbackState == Player.STATE_READY && exo.isPlaying) {
-                                lastError = null
+                            when (playbackState) {
+                                Player.STATE_BUFFERING -> {
+                                    if (expectedToPlay) scheduleFallbackMonitor()
+                                }
+                                Player.STATE_READY -> {
+                                    if (exo.isPlaying) {
+                                        lastError = null
+                                        cancelFallbackMonitor()
+                                    } else if (expectedToPlay) {
+                                        scheduleFallbackMonitor()
+                                    }
+                                }
+                                Player.STATE_ENDED -> {
+                                    expectedToPlay = false
+                                    cancelFallbackMonitor()
+                                }
+                                Player.STATE_IDLE -> {
+                                    if (expectedToPlay) scheduleFallbackMonitor()
+                                }
                             }
                             updateQueueIndex(exo.currentMediaItemIndex)
                             updatePlaybackStatus()
@@ -76,6 +96,7 @@ class TvPlayerManager(
                         ) {
                             if (!playWhenReady && !exo.isPlaying) {
                                 expectedToPlay = false
+                                cancelFallbackMonitor()
                             }
                             updatePlaybackStatus()
                         }
@@ -85,6 +106,9 @@ class TvPlayerManager(
                             reason: Int,
                         ) {
                             updateQueueIndex(exo.currentMediaItemIndex)
+                            if (expectedToPlay) {
+                                scheduleFallbackMonitor()
+                            }
                             updatePlaybackStatus()
                             persist()
                         }
@@ -101,7 +125,10 @@ class TvPlayerManager(
 
                         override fun onPlayerError(error: PlaybackException) {
                             lastError = error
-                            _isPlaying.value = false
+                            if (!tryFallbackForCurrentItem()) {
+                                _isPlaying.value = false
+                                cancelFallbackMonitor()
+                            }
                             updatePlaybackStatus()
                         }
                     },
@@ -138,6 +165,7 @@ class TvPlayerManager(
         player.setMediaItems(mediaItems, queue.currentIndex, 0L)
         player.prepare()
         player.play()
+        scheduleFallbackMonitor()
         updatePlaybackStatus()
         persist()
     }
@@ -147,12 +175,14 @@ class TvPlayerManager(
         lastError = null
         expectedToPlay = true
         player.play()
+        scheduleFallbackMonitor()
         updatePlaybackStatus()
     }
 
     override fun pause() {
         expectedToPlay = false
         player.pause()
+        cancelFallbackMonitor()
         updatePlaybackStatus()
         persist()
     }
@@ -178,6 +208,7 @@ class TvPlayerManager(
         }
         player.play()
         updateQueueIndex(clamped)
+        scheduleFallbackMonitor()
         updatePlaybackStatus()
         persist()
     }
@@ -191,12 +222,14 @@ class TvPlayerManager(
         }
         player.playWhenReady = true
         player.play()
+        scheduleFallbackMonitor()
         updatePlaybackStatus()
     }
 
     override fun stopAndClear() {
         expectedToPlay = false
         lastError = null
+        cancelFallbackMonitor()
         player.stop()
         player.clearMediaItems()
         _queue.value = PlaybackQueue()
@@ -212,6 +245,7 @@ class TvPlayerManager(
         expectedToPlay = player.playWhenReady || _isPlaying.value
         player.seekToNextMediaItem()
         updateQueueIndex(player.currentMediaItemIndex)
+        scheduleFallbackMonitor()
         updatePlaybackStatus()
         persist()
     }
@@ -221,6 +255,7 @@ class TvPlayerManager(
         expectedToPlay = player.playWhenReady || _isPlaying.value
         player.seekToPreviousMediaItem()
         updateQueueIndex(player.currentMediaItemIndex)
+        scheduleFallbackMonitor()
         updatePlaybackStatus()
         persist()
     }
@@ -230,8 +265,69 @@ class TvPlayerManager(
     override fun durationMs(): Long = player.duration.coerceAtLeast(0L)
 
     fun release() {
+        cancelFallbackMonitor()
         persist()
         player.release()
+    }
+
+    private fun scheduleFallbackMonitor() {
+        cancelFallbackMonitor()
+
+        val queueSnapshot = _queue.value
+        val trackIndex = queueSnapshot.currentIndex
+        val track = queueSnapshot.currentItem ?: return
+        if (track.fallbackStreamUrl.isNullOrBlank()) return
+
+        fallbackMonitorJob =
+            scope.launch {
+                delay(5_000L)
+                if (!expectedToPlay) return@launch
+                if (_queue.value.currentIndex != trackIndex) return@launch
+                if (player.isPlaying) return@launch
+                tryFallbackForCurrentItem()
+                updatePlaybackStatus()
+            }
+    }
+
+    private fun cancelFallbackMonitor() {
+        fallbackMonitorJob?.cancel()
+        fallbackMonitorJob = null
+    }
+
+    private fun tryFallbackForCurrentItem(): Boolean {
+        val queue = _queue.value
+        val currentItem = queue.currentItem ?: return false
+        val fallbackUrl = currentItem.fallbackStreamUrl ?: return false
+        if (currentItem.streamUrl == fallbackUrl) return false
+
+        val updatedItems =
+            queue.items.mapIndexed { index, item ->
+                if (index == queue.currentIndex) {
+                    item.copy(
+                        streamUrl = fallbackUrl,
+                        fallbackStreamUrl = null,
+                        streamFormatLabel = "MP3",
+                        streamBitrateLabel = "Max",
+                    )
+                } else {
+                    item
+                }
+            }
+
+        val updatedQueue =
+            queue.copy(
+                items = updatedItems,
+                currentPositionMs = player.currentPosition.coerceAtLeast(0L),
+            )
+
+        _queue.value = updatedQueue
+        lastError = null
+        player.setMediaItems(updatedItems.map { it.toMediaItem() }, updatedQueue.currentIndex, updatedQueue.currentPositionMs)
+        player.prepare()
+        player.play()
+        scheduleFallbackMonitor()
+        persist()
+        return true
     }
 
     private fun updateQueueIndex(index: Int) {

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseRepository.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseRepository.kt
@@ -18,6 +18,7 @@ import com.tuneflow.core.network.SearchBundle
 import com.tuneflow.core.network.SessionData
 import com.tuneflow.core.network.SessionProvider
 import com.tuneflow.core.network.SessionStore
+import com.tuneflow.core.network.TrackStreamOptions
 import com.tuneflow.core.network.toBundle
 import com.tuneflow.core.network.toDetail
 import com.tuneflow.core.network.toFavoritesBundle
@@ -141,9 +142,15 @@ class BrowseRepository(
         }
     }
 
-    suspend fun streamUrl(trackId: String): String {
-        val sessionClient = requireSessionClient().getOrElse { return "" }
-        return sessionClient.client.streamUrl(trackId)
+    suspend fun streamOptions(trackId: String): TrackStreamOptions {
+        val sessionClient =
+            requireSessionClient().getOrElse {
+                return TrackStreamOptions(
+                    directUrl = "",
+                    fallbackMp3Url = "",
+                )
+            }
+        return sessionClient.client.streamOptions(trackId)
     }
 
     private fun requireClient(session: SessionData): NavidromeClient {

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -1,5 +1,6 @@
 package com.tuneflow.feature.playback
 
+import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -43,7 +44,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
-import android.view.KeyEvent as AndroidKeyEvent
 
 @Composable
 fun NowPlayingScreen(
@@ -157,6 +157,11 @@ fun NowPlayingScreen(
                     overflow = TextOverflow.Ellipsis,
                 )
 
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    StreamBadge(label = item?.streamFormatLabel ?: "--")
+                    StreamBadge(label = item?.streamBitrateLabel ?: "--")
+                }
+
                 if (state.statusMessage != null) {
                     PlaybackStatusCard(
                         message = state.statusMessage.orEmpty(),
@@ -217,6 +222,28 @@ fun NowPlayingScreen(
                 onSelectTrack = viewModel::playFromIndex,
             )
         }
+    }
+}
+
+@Composable
+private fun StreamBadge(label: String) {
+    Box(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(14.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.74f))
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f),
+                    shape = RoundedCornerShape(14.dp),
+                )
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
     }
 }
 

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -1,6 +1,5 @@
 package com.tuneflow.feature.playback
 
-import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -44,6 +43,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import android.view.KeyEvent as AndroidKeyEvent
 
 @Composable
 fun NowPlayingScreen(


### PR DESCRIPTION
## Summary
- add a user toggle for direct FLAC with MP3 fallback vs always-MP3 playback
- show current stream format and bitrate badges on Now Playing
- harden player fallback flow and rebase branch cleanly on latest main

## Verification
- ./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt --stacktrace --console=plain
