### PR TITLE
perf: reuse OkHttpClient singleton across all API calls (#23)

### DIFF
--- a/core/network/src/main/java/com/tuneflow/core/network/NetworkFactory.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NetworkFactory.kt
@@ -8,6 +8,13 @@ import java.net.URISyntaxException
 import java.util.concurrent.TimeUnit
 
 object NetworkFactory {
+    private val sharedClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .build()
+    }
+
     fun normalizeBaseUrl(baseUrl: String): String {
         val trimmed = baseUrl.trim()
         require(trimmed.isNotBlank()) { "Server URL is required." }
@@ -55,15 +62,9 @@ object NetworkFactory {
     fun createApi(baseUrl: String): NavidromeApi {
         val normalized = "${normalizeBaseUrl(baseUrl)}/"
 
-        val client =
-            OkHttpClient.Builder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(20, TimeUnit.SECONDS)
-                .build()
-
         return Retrofit.Builder()
             .baseUrl(normalized)
-            .client(client)
+            .client(sharedClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(NavidromeApi::class.java)


### PR DESCRIPTION
## Summary

Fixes #23

### Problem
`NetworkFactory.createApi()` built a new `OkHttpClient` on every call. `OkHttpClient` owns a thread pool (`Dispatcher`) and a connection pool. Creating multiple instances wasted threads, prevented HTTP/1.1 connection reuse, and increased memory pressure — especially noticeable during playlist artwork hydration which fires many concurrent requests.

### Change
Added a `private val sharedClient: OkHttpClient by lazy { ... }` property to the `NetworkFactory` object. All `createApi()` calls now share a single `OkHttpClient` instance.

### Files Changed
- `core/network/src/main/java/com/tuneflow/core/network/NetworkFactory.kt` — single file, 8 lines changed

### No Conflicts
This branch touches only `NetworkFactory.kt`. Not touched by PR #56 or any other open PR.

### Testing
- [ ] Only one `OkHttpClient` instance exists at runtime
- [ ] No regression in API call behaviour
- [ ] Existing `NavidromeClientTest` passes