### PR TITLE
fix(tv): close transient navigation layers before screen exit

### DIFF
--- a/feature/browse/build.gradle.kts
+++ b/feature/browse/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(project(":core:player"))
     implementation(project(":core:design"))
 
+    implementation("androidx.activity:activity-compose:1.9.1")
     implementation("androidx.compose.ui:ui:1.6.8")
     implementation("androidx.compose.material3:material3:1.2.1")
     implementation("androidx.tv:tv-material:1.0.0")

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
@@ -2,6 +2,7 @@
 
 package com.tuneflow.feature.browse
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -380,12 +381,16 @@ fun PlaylistsScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val firstPlaylistFocusRequester = remember { FocusRequester() }
     val playPlaylistFocusRequester = remember { FocusRequester() }
+    val playlistReturnFocusRequester = remember { FocusRequester() }
     val playlistListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     var initialPlaylistFocusRequested by rememberSaveable { mutableStateOf(false) }
     var detailActionFocusRequested by rememberSaveable(state.selected?.id) { mutableStateOf(false) }
+    var returnFocusPlaylistId by rememberSaveable { mutableStateOf<String?>(null) }
+    var restorePlaylistFocus by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(preselectedPlaylistId) {
         if (preselectedPlaylistId != null) {
+            returnFocusPlaylistId = preselectedPlaylistId
             viewModel.loadPlaylistDetail(preselectedPlaylistId)
             onPreselectedPlaylistConsumed()
         }
@@ -407,7 +412,26 @@ fun PlaylistsScreen(
         }
     }
 
+    val hasPlaylistDetailLayer = state.selectedPlaylistId != null
     val showDetail = state.selected != null
+
+    fun closePlaylistDetail() {
+        restorePlaylistFocus = true
+        viewModel.clearSelection()
+    }
+
+    BackHandler(enabled = hasPlaylistDetailLayer, onBack = ::closePlaylistDetail)
+
+    LaunchedEffect(hasPlaylistDetailLayer, restorePlaylistFocus, state.playlists) {
+        if (!hasPlaylistDetailLayer && restorePlaylistFocus) {
+            val targetIndex = state.playlists.indexOfFirst { it.id == returnFocusPlaylistId }
+            if (targetIndex >= 0) {
+                playlistListState.scrollToItem(targetIndex)
+                runCatching { playlistReturnFocusRequester.requestFocus() }
+            }
+            restorePlaylistFocus = false
+        }
+    }
 
     LaunchedEffect(state.selected?.id) {
         if (state.selected != null) {
@@ -452,12 +476,22 @@ fun PlaylistsScreen(
                     itemsIndexed(state.playlists, key = { _, playlist -> playlist.id }) { index, playlist ->
                         PremiumPlaylistRow(
                             playlist = playlist,
-                            onClick = { viewModel.loadPlaylistDetail(playlist.id) },
+                            onClick = {
+                                returnFocusPlaylistId = playlist.id
+                                viewModel.loadPlaylistDetail(playlist.id)
+                            },
                             modifier =
                                 Modifier
                                     .boundaryLockedVerticalItem(
                                         index = index,
                                         lastIndex = state.playlists.lastIndex,
+                                    )
+                                    .then(
+                                        if (playlist.id == returnFocusPlaylistId) {
+                                            Modifier.focusRequester(playlistReturnFocusRequester)
+                                        } else {
+                                            Modifier
+                                        },
                                     )
                                     .then(
                                         if (index == 0) {

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/PlaylistsViewModel.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/PlaylistsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tuneflow.core.network.PlaylistDetail
 import com.tuneflow.core.network.PlaylistSummary
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,6 +14,7 @@ import kotlinx.coroutines.launch
 data class PlaylistsUiState(
     val isLoading: Boolean = false,
     val playlists: List<PlaylistSummary> = emptyList(),
+    val selectedPlaylistId: String? = null,
     val selected: PlaylistDetail? = null,
     val error: String? = null,
 )
@@ -20,6 +22,7 @@ data class PlaylistsUiState(
 class PlaylistsViewModel(private val repository: BrowseRepository) : ViewModel() {
     private val _uiState = MutableStateFlow(PlaylistsUiState())
     val uiState: StateFlow<PlaylistsUiState> = _uiState.asStateFlow()
+    private var playlistDetailJob: Job? = null
 
     init {
         loadPlaylists()
@@ -48,19 +51,25 @@ class PlaylistsViewModel(private val repository: BrowseRepository) : ViewModel()
     }
 
     fun loadPlaylistDetail(playlistId: String) {
-        viewModelScope.launch {
-            val result = repository.getPlaylistDetail(playlistId)
-            _uiState.update {
-                if (result.isSuccess) {
-                    it.copy(selected = result.getOrNull(), error = null)
-                } else {
-                    it.copy(selected = null, error = result.exceptionOrNull()?.message)
+        playlistDetailJob?.cancel()
+        _uiState.update { it.copy(selectedPlaylistId = playlistId, selected = null, error = null) }
+        playlistDetailJob =
+            viewModelScope.launch {
+                val result = repository.getPlaylistDetail(playlistId)
+                _uiState.update {
+                    if (it.selectedPlaylistId != playlistId) return@update it
+                    if (result.isSuccess) {
+                        it.copy(selected = result.getOrNull(), error = null)
+                    } else {
+                        it.copy(selectedPlaylistId = null, selected = null, error = result.exceptionOrNull()?.message)
+                    }
                 }
             }
-        }
     }
 
     fun clearSelection() {
-        _uiState.update { it.copy(selected = null, error = null) }
+        playlistDetailJob?.cancel()
+        playlistDetailJob = null
+        _uiState.update { it.copy(selectedPlaylistId = null, selected = null, error = null) }
     }
 }

--- a/feature/browse/src/test/java/com/tuneflow/feature/browse/PlaylistsViewModelTest.kt
+++ b/feature/browse/src/test/java/com/tuneflow/feature/browse/PlaylistsViewModelTest.kt
@@ -1,0 +1,73 @@
+package com.tuneflow.feature.browse
+
+import com.tuneflow.core.network.NavidromeClient
+import com.tuneflow.core.network.NavidromeClientProvider
+import com.tuneflow.core.network.NetworkResult
+import com.tuneflow.core.network.PlaylistDetailDto
+import com.tuneflow.core.network.PlaylistDto
+import com.tuneflow.core.network.SessionData
+import com.tuneflow.core.network.SessionProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaylistsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun clearSelection_cancelsPendingDetailAndPreventsStalePanel() =
+        runTest(dispatcher) {
+            val detailResponse = CompletableDeferred<NetworkResult<PlaylistDetailDto>>()
+            val repository = playlistRepository(detailResponse)
+            val viewModel = PlaylistsViewModel(repository)
+            runCurrent()
+
+            viewModel.loadPlaylistDetail("playlist-1")
+            runCurrent()
+            assertEquals("playlist-1", viewModel.uiState.value.selectedPlaylistId)
+
+            viewModel.clearSelection()
+            detailResponse.complete(NetworkResult.Success(PlaylistDetailDto(id = "playlist-1", name = "Favorites")))
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.selectedPlaylistId)
+            assertNull(viewModel.uiState.value.selected)
+        }
+
+    private fun playlistRepository(detailResponse: CompletableDeferred<NetworkResult<PlaylistDetailDto>>): BrowseRepository {
+        val session = SessionData("https://demo", "user", "token", "salt")
+        return BrowseRepository(
+            sessionProvider = SessionProvider { session },
+            clientProvider =
+                NavidromeClientProvider {
+                    object : NavidromeClient(it) {
+                        override suspend fun getPlaylists(): NetworkResult<List<PlaylistDto>> = NetworkResult.Success(emptyList())
+
+                        override suspend fun getPlaylist(playlistId: String): NetworkResult<PlaylistDetailDto> = detailResponse.await()
+                    }
+                },
+        )
+    }
+}

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -80,11 +80,17 @@ fun NowPlayingScreen(
         onDispose { viewModel.setActive(false) }
     }
 
+    fun closeQueue(target: QueueExitTarget = resolveQueueExitTarget(focusedQueueIndex, state.queue.items.size)) {
+        showQueue = false
+        requestStreamFocus = target == QueueExitTarget.StreamControls
+        requestTransportFocus = target == QueueExitTarget.TransportControls
+    }
+
     Box(
         modifier =
             modifier
                 .fillMaxSize()
-                .onPreviewKeyEvent { event -> handleNowPlayingKeyEvent(event, showQueue, { showQueue = false }, viewModel) },
+                .onPreviewKeyEvent { event -> handleNowPlayingKeyEvent(event, showQueue, ::closeQueue, viewModel) },
     ) {
         TuneFlowArtwork(
             model = item?.artUrl,
@@ -150,11 +156,7 @@ fun NowPlayingScreen(
                     title = "Track List",
                     state = state,
                     onSelectTrack = viewModel::playFromIndex,
-                    onQueueExit = { target ->
-                        showQueue = false
-                        requestStreamFocus = target == QueueExitTarget.StreamControls
-                        requestTransportFocus = target == QueueExitTarget.TransportControls
-                    },
+                    onQueueExit = ::closeQueue,
                     onFocusedIndexChanged = { focusedQueueIndex = it },
                     preferredExitTarget =
                         resolveQueueExitTarget(
@@ -210,9 +212,11 @@ private fun handleNowPlayingKeyEvent(
     viewModel: PlaybackViewModel,
 ): Boolean {
     if (
-        showQueue &&
-        event.type == KeyEventType.KeyDown &&
-        event.nativeKeyEvent.keyCode == AndroidKeyEvent.KEYCODE_BACK
+        resolveNowPlayingEscapeAction(
+            showQueue = showQueue,
+            isKeyDown = event.type == KeyEventType.KeyDown,
+            keyCode = event.nativeKeyEvent.keyCode,
+        ) == NowPlayingEscapeAction.CloseQueue
     ) {
         onCloseQueue()
         return true
@@ -220,6 +224,26 @@ private fun handleNowPlayingKeyEvent(
 
     return handleTransportMediaKey(event, viewModel)
 }
+
+internal enum class NowPlayingEscapeAction {
+    CloseQueue,
+    Propagate,
+}
+
+internal fun resolveNowPlayingEscapeAction(
+    showQueue: Boolean,
+    isKeyDown: Boolean,
+    keyCode: Int,
+): NowPlayingEscapeAction =
+    if (
+        showQueue &&
+        isKeyDown &&
+        keyCode == AndroidKeyEvent.KEYCODE_BACK
+    ) {
+        NowPlayingEscapeAction.CloseQueue
+    } else {
+        NowPlayingEscapeAction.Propagate
+    }
 
 @Composable
 private fun QueuePanel(
@@ -260,7 +284,6 @@ private fun QueuePanel(
                 .onPreviewKeyEvent { event ->
                     if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                     when (event.nativeKeyEvent.keyCode) {
-                        AndroidKeyEvent.KEYCODE_BACK,
                         AndroidKeyEvent.KEYCODE_DPAD_LEFT,
                         -> {
                             onQueueExit(preferredExitTarget)
@@ -382,12 +405,12 @@ private fun QueueRow(
     }
 }
 
-private enum class QueueExitTarget {
+internal enum class QueueExitTarget {
     StreamControls,
     TransportControls,
 }
 
-private fun resolveQueueExitTarget(
+internal fun resolveQueueExitTarget(
     focusedIndex: Int,
     itemCount: Int,
 ): QueueExitTarget {

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/NowPlayingNavigationTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/NowPlayingNavigationTest.kt
@@ -1,0 +1,37 @@
+package com.tuneflow.feature.playback
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NowPlayingNavigationTest {
+    @Test
+    fun backWithOpenQueue_closesQueue() {
+        val action =
+            resolveNowPlayingEscapeAction(
+                showQueue = true,
+                isKeyDown = true,
+                keyCode = KeyEvent.KEYCODE_BACK,
+            )
+
+        assertEquals(NowPlayingEscapeAction.CloseQueue, action)
+    }
+
+    @Test
+    fun backWithClosedQueue_propagatesToShell() {
+        val action =
+            resolveNowPlayingEscapeAction(
+                showQueue = false,
+                isKeyDown = true,
+                keyCode = KeyEvent.KEYCODE_BACK,
+            )
+
+        assertEquals(NowPlayingEscapeAction.Propagate, action)
+    }
+
+    @Test
+    fun queueExitTarget_matchesFocusedQueueRegion() {
+        assertEquals(QueueExitTarget.StreamControls, resolveQueueExitTarget(focusedIndex = 1, itemCount = 6))
+        assertEquals(QueueExitTarget.TransportControls, resolveQueueExitTarget(focusedIndex = 5, itemCount = 6))
+    }
+}


### PR DESCRIPTION
## Summary

- close playlist detail before leaving the Playlists section
- restore focus to the playlist that opened the detail panel
- cancel pending playlist detail requests so stale panels cannot reappear
- use one Now Playing queue-close path for Back and D-pad exit, including focus restoration
- add navigation and stale-selection unit coverage

## Validation

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`

## Notes

App exit behavior remains unchanged: confirmed exit still stops playback and clears the player by design.