### PR TITLE
feat(playback): add synchronized and scrollable lyrics

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -27,6 +27,7 @@ import com.tuneflow.core.player.TuneFlowPlaybackService
 import com.tuneflow.feature.auth.AuthRepository
 import com.tuneflow.feature.auth.LoginScreen
 import com.tuneflow.feature.browse.BrowseRepository
+import com.tuneflow.feature.playback.LyricsRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -46,6 +47,7 @@ class MainActivity : ComponentActivity() {
         val playbackPreferencesStore = PlaybackPreferencesStore(applicationContext)
         val authRepository = AuthRepository(sessionStore)
         val browseRepository = BrowseRepository(sessionStore)
+        val lyricsRepository = LyricsRepository(sessionStore)
         playerManager = PlayerGraph.get(applicationContext)
         playbackServiceIntent = Intent(this, TuneFlowPlaybackService::class.java)
         startService(playbackServiceIntent)
@@ -73,6 +75,7 @@ class MainActivity : ComponentActivity() {
                         sessionStore = sessionStore,
                         playbackPreferencesStore = playbackPreferencesStore,
                         searchHistoryStore = searchHistoryStore,
+                        lyricsRepository = lyricsRepository,
                         onExitApp = ::closeAppToSystem,
                     )
                 }
@@ -165,6 +168,7 @@ private fun TuneFlowShell(
     sessionStore: SessionStore,
     playbackPreferencesStore: PlaybackPreferencesStore,
     searchHistoryStore: SearchHistoryStore,
+    lyricsRepository: LyricsRepository,
     onExitApp: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -180,7 +184,8 @@ private fun TuneFlowShell(
         viewModel(factory = playlistsViewModelFactory(browseRepository))
     val searchViewModel: com.tuneflow.feature.browse.SearchViewModel =
         viewModel(factory = searchViewModelFactory(browseRepository, searchHistoryStore))
-    val playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel = viewModel(factory = playbackViewModelFactory(playerManager))
+    val playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel =
+        viewModel(factory = playbackViewModelFactory(playerManager, lyricsRepository))
     val playbackState by playbackViewModel.uiState.collectAsStateWithLifecycle()
     val session by sessionStore.sessionFlow.collectAsStateWithLifecycle(initialValue = null)
     val preferDirectWithFallback by playbackPreferencesStore.preferDirectWithFallbackFlow.collectAsStateWithLifecycle(initialValue = false)

--- a/app/src/main/java/com/tuneflow/tv/ViewModelFactories.kt
+++ b/app/src/main/java/com/tuneflow/tv/ViewModelFactories.kt
@@ -14,6 +14,7 @@ import com.tuneflow.feature.browse.BrowseRepository
 import com.tuneflow.feature.browse.HomeCategoryViewModel
 import com.tuneflow.feature.browse.PlaylistsViewModel
 import com.tuneflow.feature.browse.SearchViewModel
+import com.tuneflow.feature.playback.LyricsProvider
 import com.tuneflow.feature.playback.PlaybackViewModel
 
 fun authViewModelFactory(
@@ -60,7 +61,9 @@ fun searchViewModelFactory(
     initializer { SearchViewModel(repository, historyStore) }
 }
 
-fun playbackViewModelFactory(manager: TvPlayerManager) =
-    viewModelFactory {
-        initializer { PlaybackViewModel(manager) }
-    }
+fun playbackViewModelFactory(
+    manager: TvPlayerManager,
+    lyricsProvider: LyricsProvider,
+) = viewModelFactory {
+    initializer { PlaybackViewModel(manager, lyricsProvider) }
+}

--- a/core/network/src/main/java/com/tuneflow/core/network/NavidromeApi.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NavidromeApi.kt
@@ -162,6 +162,57 @@ data class Starred2Dto(
     val song: List<SongDto> = emptyList(),
 )
 
+data class OpenSubsonicExtensionsResponse(
+    val status: String,
+    val version: String,
+    val error: SubsonicError? = null,
+    val openSubsonicExtensions: List<OpenSubsonicExtensionDto> = emptyList(),
+)
+
+data class OpenSubsonicExtensionDto(
+    val name: String,
+    val versions: List<Int> = emptyList(),
+)
+
+data class LyricsBySongIdResponse(
+    val status: String,
+    val version: String,
+    val error: SubsonicError? = null,
+    val lyricsList: LyricsListDto? = null,
+)
+
+data class LyricsListDto(
+    val structuredLyrics: List<StructuredLyricsDto> = emptyList(),
+)
+
+data class StructuredLyricsDto(
+    val displayArtist: String? = null,
+    val displayTitle: String? = null,
+    val lang: String? = null,
+    val offset: Long? = null,
+    val synced: Boolean = false,
+    val kind: String? = null,
+    val line: List<LyricsLineDto> = emptyList(),
+)
+
+data class LyricsLineDto(
+    val start: Long? = null,
+    val value: String? = null,
+)
+
+data class LegacyLyricsResponse(
+    val status: String,
+    val version: String,
+    val error: SubsonicError? = null,
+    val lyrics: LegacyLyricsDto? = null,
+)
+
+data class LegacyLyricsDto(
+    val artist: String? = null,
+    val title: String? = null,
+    val value: String? = null,
+)
+
 interface NavidromeApi {
     @GET("rest/ping.view")
     suspend fun ping(
@@ -262,4 +313,37 @@ interface NavidromeApi {
         @Query("c") client: String = CLIENT_NAME,
         @Query("f") format: String = FORMAT,
     ): SubsonicEnvelope<SearchResponse>
+
+    @GET("rest/getOpenSubsonicExtensions.view")
+    suspend fun getOpenSubsonicExtensions(
+        @Query("u") username: String,
+        @Query("t") token: String,
+        @Query("s") salt: String,
+        @Query("v") version: String = API_VERSION,
+        @Query("c") client: String = CLIENT_NAME,
+        @Query("f") format: String = FORMAT,
+    ): SubsonicEnvelope<OpenSubsonicExtensionsResponse>
+
+    @GET("rest/getLyricsBySongId.view")
+    suspend fun getLyricsBySongId(
+        @Query("id") songId: String,
+        @Query("u") username: String,
+        @Query("t") token: String,
+        @Query("s") salt: String,
+        @Query("v") version: String = API_VERSION,
+        @Query("c") client: String = CLIENT_NAME,
+        @Query("f") format: String = FORMAT,
+    ): SubsonicEnvelope<LyricsBySongIdResponse>
+
+    @GET("rest/getLyrics.view")
+    suspend fun getLyrics(
+        @Query("artist") artist: String,
+        @Query("title") title: String,
+        @Query("u") username: String,
+        @Query("t") token: String,
+        @Query("s") salt: String,
+        @Query("v") version: String = API_VERSION,
+        @Query("c") client: String = CLIENT_NAME,
+        @Query("f") format: String = FORMAT,
+    ): SubsonicEnvelope<LegacyLyricsResponse>
 }

--- a/core/network/src/main/java/com/tuneflow/core/network/NavidromeClient.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NavidromeClient.kt
@@ -1,6 +1,9 @@
 package com.tuneflow.core.network
 
+import com.google.gson.JsonParseException
+import com.google.gson.stream.MalformedJsonException
 import retrofit2.HttpException
+import java.io.EOFException
 import java.io.IOException
 
 @Suppress("TooManyFunctions")
@@ -177,6 +180,72 @@ open class NavidromeClient(private val session: SessionData) {
         }
     }
 
+    open suspend fun getOpenSubsonicExtensions(): NetworkResult<List<OpenSubsonicExtensionDto>> {
+        return safeCall {
+            val response =
+                api.getOpenSubsonicExtensions(
+                    username = session.username,
+                    token = session.token,
+                    salt = session.salt,
+                ).response
+
+            if (response.status != "ok") {
+                NetworkResult.Error(
+                    message = response.error?.message ?: "Failed to discover OpenSubsonic extensions.",
+                    code = response.error?.code,
+                )
+            } else {
+                NetworkResult.Success(response.openSubsonicExtensions)
+            }
+        }
+    }
+
+    open suspend fun getLyricsBySongId(songId: String): NetworkResult<List<StructuredLyricsDto>> {
+        return safeCall {
+            val response =
+                api.getLyricsBySongId(
+                    songId = songId,
+                    username = session.username,
+                    token = session.token,
+                    salt = session.salt,
+                ).response
+
+            if (response.status != "ok") {
+                NetworkResult.Error(
+                    message = response.error?.message ?: "Failed to load lyrics.",
+                    code = response.error?.code,
+                )
+            } else {
+                NetworkResult.Success(response.lyricsList?.structuredLyrics.orEmpty())
+            }
+        }
+    }
+
+    open suspend fun getLyrics(
+        artist: String,
+        title: String,
+    ): NetworkResult<LegacyLyricsDto?> {
+        return safeCall {
+            val response =
+                api.getLyrics(
+                    artist = artist,
+                    title = title,
+                    username = session.username,
+                    token = session.token,
+                    salt = session.salt,
+                ).response
+
+            if (response.status != "ok") {
+                NetworkResult.Error(
+                    message = response.error?.message ?: "Failed to load lyrics.",
+                    code = response.error?.code,
+                )
+            } else {
+                NetworkResult.Success(response.lyrics)
+            }
+        }
+    }
+
     open fun streamOptions(trackId: String): TrackStreamOptions {
         val base =
             "${session.serverUrl}/rest/stream.view" +
@@ -192,9 +261,31 @@ open class NavidromeClient(private val session: SessionData) {
         return try {
             block()
         } catch (ex: HttpException) {
-            NetworkResult.Error(ex.message ?: "HTTP error")
+            NetworkResult.Error(
+                message = ex.message ?: "HTTP error",
+                kind = NetworkErrorKind.Http,
+                httpCode = ex.code(),
+            )
+        } catch (ex: JsonParseException) {
+            NetworkResult.Error(
+                message = ex.message ?: "Malformed server response",
+                kind = NetworkErrorKind.Parsing,
+            )
+        } catch (ex: MalformedJsonException) {
+            NetworkResult.Error(
+                message = ex.message ?: "Malformed server response",
+                kind = NetworkErrorKind.Parsing,
+            )
+        } catch (ex: EOFException) {
+            NetworkResult.Error(
+                message = ex.message ?: "Incomplete server response",
+                kind = NetworkErrorKind.Parsing,
+            )
         } catch (ex: IOException) {
-            NetworkResult.Error(ex.message ?: "Network error")
+            NetworkResult.Error(
+                message = ex.message ?: "Network error",
+                kind = NetworkErrorKind.Network,
+            )
         }
     }
 }

--- a/core/network/src/main/java/com/tuneflow/core/network/NetworkResult.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NetworkResult.kt
@@ -3,5 +3,17 @@ package com.tuneflow.core.network
 sealed interface NetworkResult<out T> {
     data class Success<T>(val data: T) : NetworkResult<T>
 
-    data class Error(val message: String) : NetworkResult<Nothing>
+    data class Error(
+        val message: String,
+        val kind: NetworkErrorKind = NetworkErrorKind.Server,
+        val code: Int? = null,
+        val httpCode: Int? = null,
+    ) : NetworkResult<Nothing>
+}
+
+enum class NetworkErrorKind {
+    Network,
+    Http,
+    Server,
+    Parsing,
 }

--- a/core/network/src/test/java/com/tuneflow/core/network/LyricsApiIntegrationTest.kt
+++ b/core/network/src/test/java/com/tuneflow/core/network/LyricsApiIntegrationTest.kt
@@ -1,0 +1,143 @@
+package com.tuneflow.core.network
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricsApiIntegrationTest {
+    @Test
+    fun authenticatedLyricsEndpoints_parseStructuredAndLegacyResponses() {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse().setBody(
+                responseBody(
+                    """
+                    "openSubsonicExtensions": [
+                      {"name": "songLyrics", "versions": [1]}
+                    ]
+                    """.trimIndent(),
+                ),
+            ),
+        )
+        server.enqueue(
+            MockResponse().setBody(
+                responseBody(
+                    """
+                    "lyricsList": {
+                      "structuredLyrics": [
+                        {
+                          "kind": "main",
+                          "lang": "eng",
+                          "offset": 125,
+                          "synced": true,
+                          "line": [
+                            {"start": 1000, "value": "First"},
+                            {"start": 2000, "value": "Second"}
+                          ]
+                        },
+                        {
+                          "kind": "main",
+                          "lang": "eng",
+                          "synced": false,
+                          "line": [{"value": "Plain"}]
+                        }
+                      ]
+                    }
+                    """.trimIndent(),
+                ),
+            ),
+        )
+        server.enqueue(
+            MockResponse().setBody(
+                responseBody(
+                    """
+                    "lyrics": {
+                      "artist": "Artist",
+                      "title": "Title",
+                      "value": "Line one\nLine two"
+                    }
+                    """.trimIndent(),
+                ),
+            ),
+        )
+        server.start()
+
+        try {
+            val client = client(server)
+            val extensions = runBlocking { client.getOpenSubsonicExtensions() } as NetworkResult.Success
+            val structured = runBlocking { client.getLyricsBySongId("song id") } as NetworkResult.Success
+            val legacy = runBlocking { client.getLyrics("Artist", "Title") } as NetworkResult.Success
+
+            assertEquals("songLyrics", extensions.data.single().name)
+            assertEquals(2, structured.data.size)
+            assertEquals(125L, structured.data.first().offset)
+            assertEquals(1_000L, structured.data.first().line.first().start)
+            assertEquals("Line one\nLine two", legacy.data?.value)
+
+            repeat(3) {
+                val path = server.takeRequest().path.orEmpty()
+                assertTrue(path.contains("u=user"))
+                assertTrue(path.contains("t=token"))
+                assertTrue(path.contains("s=salt"))
+            }
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun failedAndMalformedResponses_keepErrorDetailsDistinct() {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                {
+                  "subsonic-response": {
+                    "status": "failed",
+                    "version": "1.16.1",
+                    "error": {"code": 70, "message": "Lyrics not found"}
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+        server.enqueue(MockResponse().setBody("{"))
+        server.start()
+
+        try {
+            val client = client(server)
+            val failed = runBlocking { client.getLyricsBySongId("song-1") } as NetworkResult.Error
+            val malformed = runBlocking { client.getLyricsBySongId("song-1") } as NetworkResult.Error
+
+            assertEquals(70, failed.code)
+            assertEquals(NetworkErrorKind.Server, failed.kind)
+            assertEquals(NetworkErrorKind.Parsing, malformed.kind)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    private fun client(server: MockWebServer): NavidromeClient =
+        NavidromeClient(
+            SessionData(
+                serverUrl = server.url("/").toString(),
+                username = "user",
+                token = "token",
+                salt = "salt",
+            ),
+        )
+
+    private fun responseBody(content: String): String =
+        """
+        {
+          "subsonic-response": {
+            "status": "ok",
+            "version": "1.16.1",
+            $content
+          }
+        }
+        """.trimIndent()
+}

--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -32,6 +32,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:network"))
     implementation(project(":core:player"))
     implementation(project(":core:design"))
 

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/Lyrics.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/Lyrics.kt
@@ -1,0 +1,288 @@
+package com.tuneflow.feature.playback
+
+import com.tuneflow.core.network.DataStoreSessionProvider
+import com.tuneflow.core.network.DefaultNavidromeClientProvider
+import com.tuneflow.core.network.LegacyLyricsDto
+import com.tuneflow.core.network.NavidromeClient
+import com.tuneflow.core.network.NavidromeClientProvider
+import com.tuneflow.core.network.NetworkErrorKind
+import com.tuneflow.core.network.NetworkResult
+import com.tuneflow.core.network.SessionData
+import com.tuneflow.core.network.SessionProvider
+import com.tuneflow.core.network.SessionStore
+import com.tuneflow.core.network.StructuredLyricsDto
+import com.tuneflow.core.player.QueueItem
+
+data class LyricLine(
+    val text: String,
+    val startMs: Long? = null,
+)
+
+data class Lyrics(
+    val synchronized: Boolean,
+    val lines: List<LyricLine>,
+    val offsetMs: Long = 0L,
+)
+
+sealed interface LyricsLoadResult {
+    data class Available(val lyrics: Lyrics) : LyricsLoadResult
+
+    data object Empty : LyricsLoadResult
+
+    data object Unsupported : LyricsLoadResult
+
+    data class NetworkFailure(val message: String) : LyricsLoadResult
+
+    data class ParsingFailure(val message: String) : LyricsLoadResult
+}
+
+sealed interface LyricsUiState {
+    data object Idle : LyricsUiState
+
+    data class Loading(val trackId: String) : LyricsUiState
+
+    data class Available(
+        val trackId: String,
+        val lyrics: Lyrics,
+    ) : LyricsUiState
+
+    data class Empty(val trackId: String) : LyricsUiState
+
+    data class Unsupported(val trackId: String) : LyricsUiState
+
+    data class NetworkFailure(
+        val trackId: String,
+        val message: String,
+    ) : LyricsUiState
+
+    data class ParsingFailure(
+        val trackId: String,
+        val message: String,
+    ) : LyricsUiState
+}
+
+fun interface LyricsProvider {
+    suspend fun load(track: QueueItem): LyricsLoadResult
+}
+
+object EmptyLyricsProvider : LyricsProvider {
+    override suspend fun load(track: QueueItem): LyricsLoadResult = LyricsLoadResult.Empty
+}
+
+class LyricsRepository(
+    private val sessionProvider: SessionProvider,
+    private val clientProvider: NavidromeClientProvider = DefaultNavidromeClientProvider,
+) : LyricsProvider {
+    private enum class SongLyricsSupport {
+        Unknown,
+        Supported,
+        LegacyOnly,
+    }
+
+    private data class SessionClient(
+        val session: SessionData,
+        val client: NavidromeClient,
+    )
+
+    private var support = SongLyricsSupport.Unknown
+    private var client: SessionClient? = null
+    private val cache = mutableMapOf<String, LyricsLoadResult>()
+
+    constructor(sessionStore: SessionStore) : this(
+        sessionProvider = DataStoreSessionProvider(sessionStore),
+        clientProvider = DefaultNavidromeClientProvider,
+    )
+
+    override suspend fun load(track: QueueItem): LyricsLoadResult {
+        val cached = cache[track.id]
+        return if (cached != null) {
+            cached
+        } else {
+            val sessionClient = requireClient()
+            if (sessionClient == null) {
+                LyricsLoadResult.NetworkFailure("Not logged in")
+            } else {
+                val result =
+                    when (discoverSupport(sessionClient.client)) {
+                        SongLyricsSupport.Supported -> loadStructured(sessionClient.client, track)
+                        SongLyricsSupport.LegacyOnly,
+                        SongLyricsSupport.Unknown,
+                        -> loadLegacy(sessionClient.client, track)
+                    }
+
+                if (result is LyricsLoadResult.Available || result == LyricsLoadResult.Empty) {
+                    cache[track.id] = result
+                }
+                result
+            }
+        }
+    }
+
+    private suspend fun discoverSupport(client: NavidromeClient): SongLyricsSupport {
+        if (support != SongLyricsSupport.Unknown) return support
+        support =
+            when (val result = client.getOpenSubsonicExtensions()) {
+                is NetworkResult.Success -> {
+                    if (result.data.any { it.name.equals("songLyrics", ignoreCase = true) }) {
+                        SongLyricsSupport.Supported
+                    } else {
+                        SongLyricsSupport.LegacyOnly
+                    }
+                }
+                is NetworkResult.Error -> SongLyricsSupport.LegacyOnly
+            }
+        return support
+    }
+
+    private suspend fun loadStructured(
+        client: NavidromeClient,
+        track: QueueItem,
+    ): LyricsLoadResult =
+        when (val result = client.getLyricsBySongId(track.id)) {
+            is NetworkResult.Success -> selectStructuredLyrics(result.data)
+            is NetworkResult.Error -> {
+                when {
+                    result.isConfirmedEmpty() -> LyricsLoadResult.Empty
+                    result.isUnsupportedEndpoint() -> {
+                        support = SongLyricsSupport.LegacyOnly
+                        loadLegacy(client, track)
+                    }
+                    result.kind == NetworkErrorKind.Parsing ->
+                        LyricsLoadResult.ParsingFailure(result.message)
+                    else -> LyricsLoadResult.NetworkFailure(result.message)
+                }
+            }
+        }
+
+    private suspend fun loadLegacy(
+        client: NavidromeClient,
+        track: QueueItem,
+    ): LyricsLoadResult =
+        when (val result = client.getLyrics(track.artist, track.title)) {
+            is NetworkResult.Success -> parseLegacyLyrics(result.data)
+            is NetworkResult.Error -> {
+                when {
+                    result.isConfirmedEmpty() -> LyricsLoadResult.Empty
+                    result.isUnsupportedEndpoint() -> LyricsLoadResult.Unsupported
+                    result.kind == NetworkErrorKind.Parsing -> LyricsLoadResult.ParsingFailure(result.message)
+                    else -> LyricsLoadResult.NetworkFailure(result.message)
+                }
+            }
+        }
+
+    private suspend fun requireClient(): SessionClient? {
+        val session = sessionProvider.currentSession()
+        return if (session == null) {
+            null
+        } else {
+            client?.takeIf { it.session == session }
+                ?: run {
+                    support = SongLyricsSupport.Unknown
+                    cache.clear()
+                    runCatching { SessionClient(session, clientProvider.create(session)) }
+                        .getOrNull()
+                        ?.also { client = it }
+                }
+        }
+    }
+}
+
+internal fun selectStructuredLyrics(results: List<StructuredLyricsDto>): LyricsLoadResult {
+    val parsed = results.map(::parseStructuredCandidate)
+    val available = parsed.filterIsInstance<StructuredCandidate.Available>()
+    val selected =
+        available.firstOrNull { it.isMain && it.lyrics.synchronized }
+            ?: available.firstOrNull { it.isMain && !it.lyrics.synchronized }
+            ?: available.firstOrNull()
+
+    return when {
+        selected != null -> LyricsLoadResult.Available(selected.lyrics)
+        parsed.any { it is StructuredCandidate.Malformed } ->
+            LyricsLoadResult.ParsingFailure("Lyrics response contains invalid synchronized lines.")
+        else -> LyricsLoadResult.Empty
+    }
+}
+
+private sealed interface StructuredCandidate {
+    data class Available(
+        val lyrics: Lyrics,
+        val isMain: Boolean,
+    ) : StructuredCandidate
+
+    data object Empty : StructuredCandidate
+
+    data object Malformed : StructuredCandidate
+}
+
+private fun parseStructuredCandidate(dto: StructuredLyricsDto): StructuredCandidate {
+    val nonEmptyLines = dto.line.filter { !it.value.isNullOrBlank() }
+    return when {
+        nonEmptyLines.isEmpty() -> StructuredCandidate.Empty
+        dto.synced && nonEmptyLines.any { line -> line.start?.let { it < 0L } != false } ->
+            StructuredCandidate.Malformed
+        else -> {
+            val lines =
+                nonEmptyLines.map { line ->
+                    LyricLine(
+                        text = line.value.orEmpty().trim(),
+                        startMs = line.start?.takeIf { dto.synced },
+                    )
+                }
+            StructuredCandidate.Available(
+                lyrics =
+                    Lyrics(
+                        synchronized = dto.synced,
+                        lines = if (dto.synced) lines.sortedBy { it.startMs } else lines,
+                        offsetMs = dto.offset ?: 0L,
+                    ),
+                isMain = dto.kind.isNullOrBlank() || dto.kind.equals("main", ignoreCase = true),
+            )
+        }
+    }
+}
+
+internal fun parseLegacyLyrics(dto: LegacyLyricsDto?): LyricsLoadResult {
+    val lines =
+        dto?.value
+            ?.lineSequence()
+            ?.map(String::trim)
+            ?.filter(String::isNotEmpty)
+            ?.map { LyricLine(text = it) }
+            ?.toList()
+            .orEmpty()
+    return if (lines.isEmpty()) {
+        LyricsLoadResult.Empty
+    } else {
+        LyricsLoadResult.Available(Lyrics(synchronized = false, lines = lines))
+    }
+}
+
+internal fun resolveActiveLyricLine(
+    lyrics: Lyrics,
+    positionMs: Long,
+): Int? {
+    if (!lyrics.synchronized || lyrics.lines.isEmpty()) return null
+    val adjustedPosition = positionMs.coerceAtLeast(0L) + lyrics.offsetMs
+    val index = lyrics.lines.indexOfLast { (it.startMs ?: Long.MAX_VALUE) <= adjustedPosition }
+    return index.takeIf { it >= 0 }
+}
+
+internal fun estimateActiveLyricLine(
+    lineCount: Int,
+    positionMs: Long,
+    durationMs: Long,
+): Int? {
+    if (lineCount <= 0 || durationMs <= 0L) return null
+    val progress = positionMs.toDouble().div(durationMs.toDouble()).coerceIn(0.0, 1.0)
+    return (progress * (lineCount - 1)).toInt().coerceIn(0, lineCount - 1)
+}
+
+private fun NetworkResult.Error.isConfirmedEmpty(): Boolean = code == 70
+
+private fun NetworkResult.Error.isUnsupportedEndpoint(): Boolean {
+    if (httpCode == 404 || httpCode == 405 || httpCode == 501) return true
+    val normalized = message.lowercase()
+    return normalized.contains("unsupported endpoint") ||
+        normalized.contains("unknown endpoint") ||
+        normalized.contains("not implemented")
+}

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/LyricsRenderer.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/LyricsRenderer.kt
@@ -1,0 +1,224 @@
+package com.tuneflow.feature.playback
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tuneflow.core.design.TuneFlowShapes
+import kotlinx.coroutines.launch
+import android.view.KeyEvent as AndroidKeyEvent
+
+@Composable
+fun LyricsRenderer(
+    lyrics: Lyrics,
+    positionMs: Long,
+    durationMs: Long,
+    modifier: Modifier = Modifier,
+    autoFollow: Boolean = true,
+    interactive: Boolean = true,
+    estimateUnsynchronized: Boolean = false,
+    onManualScroll: () -> Unit = {},
+) {
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+    val activeIndex =
+        when {
+            lyrics.synchronized -> resolveActiveLyricLine(lyrics, positionMs)
+            estimateUnsynchronized -> estimateActiveLyricLine(lyrics.lines.size, positionMs, durationMs)
+            else -> null
+        }
+
+    LaunchedEffect(activeIndex, autoFollow, lyrics) {
+        if (autoFollow && activeIndex != null) {
+            listState.animateScrollToItem((activeIndex - 2).coerceAtLeast(0))
+        }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier =
+            modifier.onPreviewKeyEvent { event ->
+                if (!interactive || event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                when (event.nativeKeyEvent.keyCode) {
+                    AndroidKeyEvent.KEYCODE_DPAD_UP,
+                    AndroidKeyEvent.KEYCODE_DPAD_DOWN,
+                    -> {
+                        onManualScroll()
+                        false
+                    }
+                    AndroidKeyEvent.KEYCODE_PAGE_UP,
+                    AndroidKeyEvent.KEYCODE_PAGE_DOWN,
+                    -> {
+                        onManualScroll()
+                        val visibleCount = listState.layoutInfo.visibleItemsInfo.size.coerceAtLeast(1)
+                        val direction = if (event.nativeKeyEvent.keyCode == AndroidKeyEvent.KEYCODE_PAGE_UP) -1 else 1
+                        val target =
+                            (listState.firstVisibleItemIndex + direction * visibleCount)
+                                .coerceIn(0, lyrics.lines.lastIndex)
+                        scope.launch { listState.animateScrollToItem(target) }
+                        true
+                    }
+                    else -> false
+                }
+            },
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        itemsIndexed(lyrics.lines) { index, line ->
+            LyricLineRow(
+                text = line.text,
+                active = index == activeIndex,
+                interactive = interactive,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LyricLineRow(
+    text: String,
+    active: Boolean,
+    interactive: Boolean,
+) {
+    var focused by remember { mutableStateOf(false) }
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(TuneFlowShapes.row)
+                .background(
+                    when {
+                        focused -> MaterialTheme.colorScheme.primary.copy(alpha = 0.24f)
+                        active -> MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
+                        else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.18f)
+                    },
+                )
+                .border(
+                    width = if (focused) 2.dp else 1.dp,
+                    color =
+                        if (focused || active) {
+                            MaterialTheme.colorScheme.primary.copy(alpha = if (focused) 1f else 0.52f)
+                        } else {
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.12f)
+                        },
+                    shape = TuneFlowShapes.row,
+                )
+                .onFocusChanged { focused = it.hasFocus }
+                .then(if (interactive) Modifier.focusable() else Modifier)
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = text,
+            style =
+                if (active) {
+                    MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                } else {
+                    MaterialTheme.typography.titleMedium
+                },
+            color =
+                if (active) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+        )
+    }
+}
+
+@Composable
+internal fun LyricsPanel(
+    lyrics: Lyrics,
+    positionMs: Long,
+    durationMs: Long,
+    onExit: () -> Unit,
+) {
+    var autoFollow by remember(lyrics) { mutableStateOf(true) }
+
+    Column(
+        modifier =
+            Modifier
+                .width(312.dp)
+                .fillMaxHeight()
+                .clip(TuneFlowShapes.card)
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.76f))
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.16f),
+                    shape = TuneFlowShapes.card,
+                )
+                .onPreviewKeyEvent { event ->
+                    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    when (event.nativeKeyEvent.keyCode) {
+                        AndroidKeyEvent.KEYCODE_DPAD_LEFT -> {
+                            onExit()
+                            true
+                        }
+                        AndroidKeyEvent.KEYCODE_DPAD_UP,
+                        AndroidKeyEvent.KEYCODE_DPAD_DOWN,
+                        AndroidKeyEvent.KEYCODE_PAGE_UP,
+                        AndroidKeyEvent.KEYCODE_PAGE_DOWN,
+                        -> {
+                            autoFollow = false
+                            false
+                        }
+                        else -> false
+                    }
+                }
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "Lyrics",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            PlaybackTextButton(
+                label = "Follow",
+                accent = autoFollow,
+                onClick = { autoFollow = true },
+                modifier = Modifier.width(104.dp).height(44.dp),
+                requestFocus = true,
+            )
+        }
+        LyricsRenderer(
+            lyrics = lyrics,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            modifier = Modifier.fillMaxWidth().weight(1f),
+            autoFollow = autoFollow,
+            interactive = true,
+            onManualScroll = { autoFollow = false },
+        )
+    }
+}

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
@@ -58,9 +58,11 @@ internal fun NowPlayingPrimaryColumn(
     artSize: Dp,
     artFrameHeight: Dp,
     streamModeLabel: String,
-    showQueue: Boolean,
+    activePanel: NowPlayingPanel,
+    hasLyrics: Boolean,
     onCycleStreamMode: () -> Unit,
     onToggleQueue: () -> Unit,
+    onToggleLyrics: () -> Unit,
     onCyclePlaybackMode: () -> Unit,
     onRetry: () -> Unit,
     onPrevious: () -> Unit,
@@ -69,8 +71,12 @@ internal fun NowPlayingPrimaryColumn(
     compactTransport: Boolean,
     autoFocusTransport: Boolean,
     autoFocusStreamMode: Boolean,
+    autoFocusQueue: Boolean,
+    autoFocusLyrics: Boolean,
     onAutoFocusConsumed: () -> Unit,
     onStreamModeFocusConsumed: () -> Unit,
+    onQueueFocusConsumed: () -> Unit,
+    onLyricsFocusConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -86,13 +92,19 @@ internal fun NowPlayingPrimaryColumn(
         StreamControlRow(
             streamModeLabel = streamModeLabel,
             bitrateLabel = item?.streamBitrateLabel ?: "--",
-            showQueue = showQueue,
+            activePanel = activePanel,
+            hasLyrics = hasLyrics,
             onCycleStreamMode = onCycleStreamMode,
             autoFocusStreamMode = autoFocusStreamMode,
             onStreamModeFocusConsumed = onStreamModeFocusConsumed,
             onToggleQueue = onToggleQueue,
+            onToggleLyrics = onToggleLyrics,
             playbackMode = state.playbackMode,
             onCyclePlaybackMode = onCyclePlaybackMode,
+            autoFocusQueue = autoFocusQueue,
+            autoFocusLyrics = autoFocusLyrics,
+            onQueueFocusConsumed = onQueueFocusConsumed,
+            onLyricsFocusConsumed = onLyricsFocusConsumed,
         )
 
         state.statusMessage?.let {
@@ -248,13 +260,19 @@ internal fun StreamModeButton(
 internal fun StreamControlRow(
     streamModeLabel: String,
     bitrateLabel: String,
-    showQueue: Boolean,
+    activePanel: NowPlayingPanel,
+    hasLyrics: Boolean,
     playbackMode: PlaybackMode,
     onCycleStreamMode: () -> Unit,
     autoFocusStreamMode: Boolean,
     onStreamModeFocusConsumed: () -> Unit,
     onToggleQueue: () -> Unit,
+    onToggleLyrics: () -> Unit,
     onCyclePlaybackMode: () -> Unit,
+    autoFocusQueue: Boolean,
+    autoFocusLyrics: Boolean,
+    onQueueFocusConsumed: () -> Unit,
+    onLyricsFocusConsumed: () -> Unit,
 ) {
     Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
         StreamModeButton(
@@ -269,9 +287,19 @@ internal fun StreamControlRow(
             onClick = onCyclePlaybackMode,
         )
         QueueToggleIconButton(
-            active = showQueue,
+            active = activePanel == NowPlayingPanel.TrackList,
             onClick = onToggleQueue,
+            requestFocus = autoFocusQueue,
+            onRequestedFocusApplied = onQueueFocusConsumed,
         )
+        if (hasLyrics) {
+            LyricsToggleButton(
+                active = activePanel == NowPlayingPanel.Lyrics,
+                onClick = onToggleLyrics,
+                requestFocus = autoFocusLyrics,
+                onRequestedFocusApplied = onLyricsFocusConsumed,
+            )
+        }
     }
 }
 
@@ -329,12 +357,33 @@ private fun PlaybackModeIconButton(
 private fun QueueToggleIconButton(
     active: Boolean,
     onClick: () -> Unit,
+    requestFocus: Boolean,
+    onRequestedFocusApplied: () -> Unit,
 ) {
     PlaybackStateIconButton(
         iconResId = if (active) R.drawable.tracklist_enabled else R.drawable.tracklist_disabled,
         contentDescription = if (active) "Hide track list" else "Show track list",
         active = active,
         onClick = onClick,
+        requestFocus = requestFocus,
+        onRequestedFocusApplied = onRequestedFocusApplied,
+    )
+}
+
+@Composable
+private fun LyricsToggleButton(
+    active: Boolean,
+    onClick: () -> Unit,
+    requestFocus: Boolean,
+    onRequestedFocusApplied: () -> Unit,
+) {
+    PlaybackTextButton(
+        label = "Lyrics",
+        accent = active,
+        onClick = onClick,
+        modifier = Modifier.width(96.dp).height(44.dp),
+        requestFocus = requestFocus,
+        onRequestedFocusApplied = onRequestedFocusApplied,
     )
 }
 
@@ -344,13 +393,24 @@ private fun PlaybackStateIconButton(
     contentDescription: String,
     active: Boolean,
     onClick: () -> Unit,
+    requestFocus: Boolean = false,
+    onRequestedFocusApplied: () -> Unit = {},
 ) {
     var focused by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(requestFocus) {
+        if (requestFocus) {
+            focusRequester.requestFocus()
+            onRequestedFocusApplied()
+        }
+    }
 
     Box(
         modifier =
             Modifier
                 .size(44.dp)
+                .focusRequester(focusRequester)
                 .scale(if (focused) 1.03f else 1f)
                 .clip(TuneFlowShapes.button)
                 .background(

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.delay
 import android.view.KeyEvent as AndroidKeyEvent
 
 @Composable
+@Suppress("CyclomaticComplexMethod")
 fun NowPlayingScreen(
     viewModel: PlaybackViewModel,
     streamModeLabel: String,
@@ -67,30 +68,64 @@ fun NowPlayingScreen(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val lyricsState by viewModel.lyricsState.collectAsStateWithLifecycle()
     val item = state.queue.currentItem
-    var showQueue by rememberSaveable { mutableStateOf(false) }
+    val availableLyrics =
+        (lyricsState as? LyricsUiState.Available)
+            ?.takeIf { it.trackId == item?.id }
+            ?.lyrics
+    var activePanel by rememberSaveable { mutableStateOf(NowPlayingPanel.None) }
     var requestStreamFocus by rememberSaveable { mutableStateOf(false) }
     var requestTransportFocus by rememberSaveable { mutableStateOf(false) }
+    var requestQueueFocus by rememberSaveable { mutableStateOf(false) }
+    var requestLyricsFocus by rememberSaveable { mutableStateOf(false) }
     var focusedQueueIndex by rememberSaveable { mutableIntStateOf(0) }
-    val artSize by animateDpAsState(targetValue = if (showQueue) 152.dp else 180.dp, label = "now-playing-art-size")
-    val artFrameHeight by animateDpAsState(targetValue = if (showQueue) 176.dp else 200.dp, label = "now-playing-art-frame-height")
+    val panelVisible = activePanel != NowPlayingPanel.None
+    val artSize by animateDpAsState(targetValue = if (panelVisible) 152.dp else 180.dp, label = "now-playing-art-size")
+    val artFrameHeight by animateDpAsState(targetValue = if (panelVisible) 176.dp else 200.dp, label = "now-playing-art-frame-height")
 
     DisposableEffect(Unit) {
         viewModel.setActive(true)
         onDispose { viewModel.setActive(false) }
     }
 
-    fun closeQueue(target: QueueExitTarget = resolveQueueExitTarget(focusedQueueIndex, state.queue.items.size)) {
-        showQueue = false
+    LaunchedEffect(item?.id, availableLyrics) {
+        if (activePanel == NowPlayingPanel.Lyrics && availableLyrics == null) {
+            activePanel = NowPlayingPanel.None
+        }
+    }
+
+    fun clearRequestedFocus() {
+        requestStreamFocus = false
+        requestTransportFocus = false
+        requestQueueFocus = false
+        requestLyricsFocus = false
+    }
+
+    fun closeQueue(target: QueueExitTarget) {
+        activePanel = NowPlayingPanel.None
         requestStreamFocus = target == QueueExitTarget.StreamControls
         requestTransportFocus = target == QueueExitTarget.TransportControls
+    }
+
+    fun closePanelToButton() {
+        val closedPanel = activePanel
+        activePanel = NowPlayingPanel.None
+        when (resolvePanelFocusTarget(closedPanel, availableLyrics != null)) {
+            PanelFocusTarget.QueueButton -> requestQueueFocus = true
+            PanelFocusTarget.LyricsButton -> requestLyricsFocus = true
+            PanelFocusTarget.None -> Unit
+        }
     }
 
     Box(
         modifier =
             modifier
                 .fillMaxSize()
-                .onPreviewKeyEvent { event -> handleNowPlayingKeyEvent(event, showQueue, ::closeQueue, viewModel) },
+                .onPreviewKeyEvent {
+                        event ->
+                    handleNowPlayingKeyEvent(event, activePanel, ::closePanelToButton, viewModel)
+                },
     ) {
         TuneFlowArtwork(
             model = item?.artUrl,
@@ -128,42 +163,63 @@ fun NowPlayingScreen(
                 artSize = artSize,
                 artFrameHeight = artFrameHeight,
                 streamModeLabel = streamModeLabel,
-                showQueue = showQueue,
+                activePanel = activePanel,
+                hasLyrics = availableLyrics != null,
                 onCycleStreamMode = onCycleStreamMode,
                 onToggleQueue = {
-                    showQueue = !showQueue
-                    requestStreamFocus = false
-                    requestTransportFocus = false
+                    activePanel = toggleNowPlayingPanel(activePanel, NowPlayingPanel.TrackList)
+                    clearRequestedFocus()
+                },
+                onToggleLyrics = {
+                    activePanel = toggleNowPlayingPanel(activePanel, NowPlayingPanel.Lyrics)
+                    clearRequestedFocus()
                 },
                 onCyclePlaybackMode = viewModel::cyclePlaybackMode,
                 onRetry = viewModel::retry,
                 onPrevious = viewModel::previous,
                 onTogglePlayPause = viewModel::togglePlayPause,
                 onNext = viewModel::next,
-                compactTransport = showQueue,
+                compactTransport = panelVisible,
                 autoFocusTransport = autoFocusTransport || requestTransportFocus,
                 autoFocusStreamMode = requestStreamFocus,
+                autoFocusQueue = requestQueueFocus,
+                autoFocusLyrics = requestLyricsFocus,
                 onAutoFocusConsumed = onAutoFocusConsumed,
                 onStreamModeFocusConsumed = { requestStreamFocus = false },
+                onQueueFocusConsumed = { requestQueueFocus = false },
+                onLyricsFocusConsumed = { requestLyricsFocus = false },
             )
 
             AnimatedVisibility(
-                visible = showQueue,
+                visible = panelVisible,
                 enter = fadeIn() + slideInHorizontally(initialOffsetX = { it / 4 }),
                 exit = fadeOut() + slideOutHorizontally(targetOffsetX = { it / 4 }),
             ) {
-                QueuePanel(
-                    title = "Track List",
-                    state = state,
-                    onSelectTrack = viewModel::playFromIndex,
-                    onQueueExit = ::closeQueue,
-                    onFocusedIndexChanged = { focusedQueueIndex = it },
-                    preferredExitTarget =
-                        resolveQueueExitTarget(
-                            focusedIndex = focusedQueueIndex,
-                            itemCount = state.queue.items.size,
-                        ),
-                )
+                when (activePanel) {
+                    NowPlayingPanel.TrackList ->
+                        QueuePanel(
+                            title = "Track List",
+                            state = state,
+                            onSelectTrack = viewModel::playFromIndex,
+                            onQueueExit = ::closeQueue,
+                            onFocusedIndexChanged = { focusedQueueIndex = it },
+                            preferredExitTarget =
+                                resolveQueueExitTarget(
+                                    focusedIndex = focusedQueueIndex,
+                                    itemCount = state.queue.items.size,
+                                ),
+                        )
+                    NowPlayingPanel.Lyrics ->
+                        availableLyrics?.let { lyrics ->
+                            LyricsPanel(
+                                lyrics = lyrics,
+                                positionMs = state.positionMs,
+                                durationMs = state.durationMs,
+                                onExit = ::closePanelToButton,
+                            )
+                        }
+                    NowPlayingPanel.None -> Unit
+                }
             }
         }
     }
@@ -207,18 +263,18 @@ private fun handleTransportMediaKey(
 
 private fun handleNowPlayingKeyEvent(
     event: androidx.compose.ui.input.key.KeyEvent,
-    showQueue: Boolean,
-    onCloseQueue: () -> Unit,
+    activePanel: NowPlayingPanel,
+    onClosePanel: () -> Unit,
     viewModel: PlaybackViewModel,
 ): Boolean {
     if (
         resolveNowPlayingEscapeAction(
-            showQueue = showQueue,
+            activePanel = activePanel,
             isKeyDown = event.type == KeyEventType.KeyDown,
             keyCode = event.nativeKeyEvent.keyCode,
-        ) == NowPlayingEscapeAction.CloseQueue
+        ) == NowPlayingEscapeAction.ClosePanel
     ) {
-        onCloseQueue()
+        onClosePanel()
         return true
     }
 
@@ -226,21 +282,48 @@ private fun handleNowPlayingKeyEvent(
 }
 
 internal enum class NowPlayingEscapeAction {
-    CloseQueue,
+    ClosePanel,
     Propagate,
 }
 
+internal enum class NowPlayingPanel {
+    None,
+    TrackList,
+    Lyrics,
+}
+
+internal fun toggleNowPlayingPanel(
+    current: NowPlayingPanel,
+    requested: NowPlayingPanel,
+): NowPlayingPanel = if (current == requested) NowPlayingPanel.None else requested
+
+internal enum class PanelFocusTarget {
+    None,
+    QueueButton,
+    LyricsButton,
+}
+
+internal fun resolvePanelFocusTarget(
+    closedPanel: NowPlayingPanel,
+    lyricsAvailable: Boolean,
+): PanelFocusTarget =
+    when (closedPanel) {
+        NowPlayingPanel.TrackList -> PanelFocusTarget.QueueButton
+        NowPlayingPanel.Lyrics -> if (lyricsAvailable) PanelFocusTarget.LyricsButton else PanelFocusTarget.None
+        NowPlayingPanel.None -> PanelFocusTarget.None
+    }
+
 internal fun resolveNowPlayingEscapeAction(
-    showQueue: Boolean,
+    activePanel: NowPlayingPanel,
     isKeyDown: Boolean,
     keyCode: Int,
 ): NowPlayingEscapeAction =
     if (
-        showQueue &&
+        activePanel != NowPlayingPanel.None &&
         isKeyDown &&
         keyCode == AndroidKeyEvent.KEYCODE_BACK
     ) {
-        NowPlayingEscapeAction.CloseQueue
+        NowPlayingEscapeAction.ClosePanel
     } else {
         NowPlayingEscapeAction.Propagate
     }

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/PlaybackViewModel.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/PlaybackViewModel.kt
@@ -14,10 +14,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
@@ -34,11 +37,14 @@ data class NowPlayingUiState(
 @OptIn(ExperimentalCoroutinesApi::class)
 class PlaybackViewModel(
     private val playerManager: PlaybackController,
+    private val lyricsProvider: LyricsProvider = EmptyLyricsProvider,
     private val positionTicker: Flow<Unit> = defaultTickerFlow(),
     private val scopeOverride: CoroutineScope? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(NowPlayingUiState())
     val uiState: StateFlow<NowPlayingUiState> = _uiState.asStateFlow()
+    private val _lyricsState = MutableStateFlow<LyricsUiState>(LyricsUiState.Idle)
+    val lyricsState: StateFlow<LyricsUiState> = _lyricsState.asStateFlow()
     private val isActive = MutableStateFlow(false)
 
     init {
@@ -77,6 +83,20 @@ class PlaybackViewModel(
                 _uiState.value = it
             }
         }
+        scope.launch {
+            playerManager.queue
+                .map { it.currentItem }
+                .distinctUntilChangedBy { it?.id }
+                .collectLatest { track ->
+                    if (track == null) {
+                        _lyricsState.value = LyricsUiState.Idle
+                        return@collectLatest
+                    }
+
+                    _lyricsState.value = LyricsUiState.Loading(track.id)
+                    _lyricsState.value = lyricsProvider.load(track).toUiState(track.id)
+                }
+        }
     }
 
     fun setActive(active: Boolean) {
@@ -107,6 +127,15 @@ class PlaybackViewModel(
 
     fun cyclePlaybackMode() = playerManager.cyclePlaybackMode()
 }
+
+private fun LyricsLoadResult.toUiState(trackId: String): LyricsUiState =
+    when (this) {
+        is LyricsLoadResult.Available -> LyricsUiState.Available(trackId, lyrics)
+        LyricsLoadResult.Empty -> LyricsUiState.Empty(trackId)
+        LyricsLoadResult.Unsupported -> LyricsUiState.Unsupported(trackId)
+        is LyricsLoadResult.NetworkFailure -> LyricsUiState.NetworkFailure(trackId, message)
+        is LyricsLoadResult.ParsingFailure -> LyricsUiState.ParsingFailure(trackId, message)
+    }
 
 private data class PlaybackSnapshot(
     val queue: PlaybackQueue,

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/LyricsRepositoryTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/LyricsRepositoryTest.kt
@@ -1,0 +1,155 @@
+package com.tuneflow.feature.playback
+
+import com.tuneflow.core.network.LegacyLyricsDto
+import com.tuneflow.core.network.LyricsLineDto
+import com.tuneflow.core.network.NavidromeClient
+import com.tuneflow.core.network.NavidromeClientProvider
+import com.tuneflow.core.network.NetworkErrorKind
+import com.tuneflow.core.network.NetworkResult
+import com.tuneflow.core.network.OpenSubsonicExtensionDto
+import com.tuneflow.core.network.SessionData
+import com.tuneflow.core.network.SessionProvider
+import com.tuneflow.core.network.StructuredLyricsDto
+import com.tuneflow.core.player.QueueItem
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricsRepositoryTest {
+    private val session = SessionData("https://music.example", "user", "token", "salt")
+    private val track = QueueItem("song-1", "Title", "Artist", "Album", streamUrl = "stream")
+
+    @Test
+    fun extensionSupported_usesSongIdAndCachesSuccessfulResult() =
+        runTest {
+            val client = FakeLyricsClient(session)
+            val repository = repository(client)
+
+            val first = repository.load(track)
+            val second = repository.load(track)
+
+            assertTrue(first is LyricsLoadResult.Available)
+            assertEquals(first, second)
+            assertEquals(1, client.bySongIdCalls)
+            assertEquals(0, client.legacyCalls)
+        }
+
+    @Test
+    fun extensionMissing_usesLegacyArtistAndTitle() =
+        runTest {
+            val client = FakeLyricsClient(session, extensions = NetworkResult.Success(emptyList()))
+            val result = repository(client).load(track)
+
+            assertTrue(result is LyricsLoadResult.Available)
+            assertEquals(0, client.bySongIdCalls)
+            assertEquals(1, client.legacyCalls)
+            assertEquals("Artist" to "Title", client.lastLegacyQuery)
+        }
+
+    @Test
+    fun unsupportedSongIdEndpoint_fallsBackToLegacy() =
+        runTest {
+            val client =
+                FakeLyricsClient(
+                    session = session,
+                    structured = NetworkResult.Error("unknown endpoint"),
+                )
+
+            val result = repository(client).load(track)
+
+            assertTrue(result is LyricsLoadResult.Available)
+            assertEquals(1, client.bySongIdCalls)
+            assertEquals(1, client.legacyCalls)
+        }
+
+    @Test
+    fun confirmedEmpty_isCachedButFailuresAreNot() =
+        runTest {
+            val emptyClient =
+                FakeLyricsClient(
+                    session = session,
+                    structured = NetworkResult.Error("Lyrics not found", code = 70),
+                )
+            val emptyRepository = repository(emptyClient)
+            assertEquals(LyricsLoadResult.Empty, emptyRepository.load(track))
+            assertEquals(LyricsLoadResult.Empty, emptyRepository.load(track))
+            assertEquals(1, emptyClient.bySongIdCalls)
+
+            val failedClient =
+                FakeLyricsClient(
+                    session = session,
+                    structured =
+                        NetworkResult.Error(
+                            "connection lost",
+                            kind = NetworkErrorKind.Network,
+                        ),
+                )
+            val failedRepository = repository(failedClient)
+            assertTrue(failedRepository.load(track) is LyricsLoadResult.NetworkFailure)
+            assertTrue(failedRepository.load(track) is LyricsLoadResult.NetworkFailure)
+            assertEquals(2, failedClient.bySongIdCalls)
+        }
+
+    @Test
+    fun unsupportedAndParsingFailures_areDistinct() =
+        runTest {
+            val unsupported =
+                FakeLyricsClient(
+                    session = session,
+                    extensions = NetworkResult.Success(emptyList()),
+                    legacy = NetworkResult.Error("unsupported endpoint"),
+                )
+            assertEquals(LyricsLoadResult.Unsupported, repository(unsupported).load(track))
+
+            val malformed =
+                FakeLyricsClient(
+                    session = session,
+                    structured = NetworkResult.Error("bad json", kind = NetworkErrorKind.Parsing),
+                )
+            assertTrue(repository(malformed).load(track) is LyricsLoadResult.ParsingFailure)
+        }
+
+    private fun repository(client: NavidromeClient): LyricsRepository =
+        LyricsRepository(
+            sessionProvider = SessionProvider { session },
+            clientProvider = NavidromeClientProvider { client },
+        )
+}
+
+private class FakeLyricsClient(
+    session: SessionData,
+    private val extensions: NetworkResult<List<OpenSubsonicExtensionDto>> =
+        NetworkResult.Success(listOf(OpenSubsonicExtensionDto("songLyrics", listOf(1)))),
+    private val structured: NetworkResult<List<StructuredLyricsDto>> =
+        NetworkResult.Success(
+            listOf(
+                StructuredLyricsDto(
+                    synced = true,
+                    line = listOf(LyricsLineDto(start = 1_000L, value = "Timed lyric")),
+                ),
+            ),
+        ),
+    private val legacy: NetworkResult<LegacyLyricsDto?> =
+        NetworkResult.Success(LegacyLyricsDto(value = "Legacy lyric")),
+) : NavidromeClient(session) {
+    var bySongIdCalls = 0
+    var legacyCalls = 0
+    var lastLegacyQuery: Pair<String, String>? = null
+
+    override suspend fun getOpenSubsonicExtensions(): NetworkResult<List<OpenSubsonicExtensionDto>> = extensions
+
+    override suspend fun getLyricsBySongId(songId: String): NetworkResult<List<StructuredLyricsDto>> {
+        bySongIdCalls += 1
+        return structured
+    }
+
+    override suspend fun getLyrics(
+        artist: String,
+        title: String,
+    ): NetworkResult<LegacyLyricsDto?> {
+        legacyCalls += 1
+        lastLegacyQuery = artist to title
+        return legacy
+    }
+}

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/LyricsTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/LyricsTest.kt
@@ -1,0 +1,88 @@
+package com.tuneflow.feature.playback
+
+import com.tuneflow.core.network.LegacyLyricsDto
+import com.tuneflow.core.network.LyricsLineDto
+import com.tuneflow.core.network.StructuredLyricsDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricsTest {
+    @Test
+    fun selection_prefersMainSynchronizedThenMainUnsynchronized() {
+        val translation = structured(kind = "translation", synced = true, text = "Translation", startMs = 10L)
+        val mainUnsynced = structured(kind = "main", synced = false, text = "Main plain")
+        val mainSynced = structured(kind = "main", synced = true, text = "Main timed", startMs = 20L)
+
+        val result = selectStructuredLyrics(listOf(translation, mainUnsynced, mainSynced))
+
+        assertEquals("Main timed", (result as LyricsLoadResult.Available).lyrics.lines.single().text)
+    }
+
+    @Test
+    fun selection_usesMainUnsynchronizedBeforeFirstNonMainResult() {
+        val result =
+            selectStructuredLyrics(
+                listOf(
+                    structured(kind = "translation", synced = true, text = "Translation", startMs = 10L),
+                    structured(kind = null, synced = false, text = "Default main"),
+                ),
+            )
+
+        assertEquals("Default main", (result as LyricsLoadResult.Available).lyrics.lines.single().text)
+        assertEquals(false, result.lyrics.synchronized)
+    }
+
+    @Test
+    fun synchronizedMalformedLines_haveDistinctParsingResult() {
+        val result = selectStructuredLyrics(listOf(structured(kind = "main", synced = true, text = "Missing time")))
+
+        assertTrue(result is LyricsLoadResult.ParsingFailure)
+    }
+
+    @Test
+    fun emptyResponses_haveDistinctEmptyResult() {
+        assertEquals(LyricsLoadResult.Empty, selectStructuredLyrics(emptyList()))
+        assertEquals(LyricsLoadResult.Empty, parseLegacyLyrics(LegacyLyricsDto(value = "  \n\n")))
+    }
+
+    @Test
+    fun legacyLyrics_areUnsynchronizedLines() {
+        val result = parseLegacyLyrics(LegacyLyricsDto(value = "First\n\nSecond")) as LyricsLoadResult.Available
+
+        assertEquals(false, result.lyrics.synchronized)
+        assertEquals(listOf("First", "Second"), result.lyrics.lines.map { it.text })
+    }
+
+    @Test
+    fun activeLine_honorsBoundariesOffsetAndBackwardSeek() {
+        val lyrics =
+            Lyrics(
+                synchronized = true,
+                offsetMs = 100L,
+                lines =
+                    listOf(
+                        LyricLine("One", 1_000L),
+                        LyricLine("Two", 2_000L),
+                        LyricLine("Three", 3_000L),
+                    ),
+            )
+
+        assertNull(resolveActiveLyricLine(lyrics, 899L))
+        assertEquals(0, resolveActiveLyricLine(lyrics, 900L))
+        assertEquals(2, resolveActiveLyricLine(lyrics, 2_900L))
+        assertEquals(0, resolveActiveLyricLine(lyrics, 1_200L))
+    }
+
+    private fun structured(
+        kind: String?,
+        synced: Boolean,
+        text: String,
+        startMs: Long? = null,
+    ) = StructuredLyricsDto(
+        kind = kind,
+        synced = synced,
+        line = listOf(LyricsLineDto(start = startMs, value = text)),
+    )
+}

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/NowPlayingNavigationTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/NowPlayingNavigationTest.kt
@@ -9,24 +9,52 @@ class NowPlayingNavigationTest {
     fun backWithOpenQueue_closesQueue() {
         val action =
             resolveNowPlayingEscapeAction(
-                showQueue = true,
+                activePanel = NowPlayingPanel.TrackList,
                 isKeyDown = true,
                 keyCode = KeyEvent.KEYCODE_BACK,
             )
 
-        assertEquals(NowPlayingEscapeAction.CloseQueue, action)
+        assertEquals(NowPlayingEscapeAction.ClosePanel, action)
     }
 
     @Test
     fun backWithClosedQueue_propagatesToShell() {
         val action =
             resolveNowPlayingEscapeAction(
-                showQueue = false,
+                activePanel = NowPlayingPanel.None,
                 isKeyDown = true,
                 keyCode = KeyEvent.KEYCODE_BACK,
             )
 
         assertEquals(NowPlayingEscapeAction.Propagate, action)
+    }
+
+    @Test
+    fun panels_areMutuallyExclusiveAndActiveButtonClosesPanel() {
+        assertEquals(
+            NowPlayingPanel.Lyrics,
+            toggleNowPlayingPanel(NowPlayingPanel.TrackList, NowPlayingPanel.Lyrics),
+        )
+        assertEquals(
+            NowPlayingPanel.None,
+            toggleNowPlayingPanel(NowPlayingPanel.Lyrics, NowPlayingPanel.Lyrics),
+        )
+    }
+
+    @Test
+    fun backRestoresFocusToButtonThatOpenedPanel() {
+        assertEquals(
+            PanelFocusTarget.QueueButton,
+            resolvePanelFocusTarget(NowPlayingPanel.TrackList, lyricsAvailable = true),
+        )
+        assertEquals(
+            PanelFocusTarget.LyricsButton,
+            resolvePanelFocusTarget(NowPlayingPanel.Lyrics, lyricsAvailable = true),
+        )
+        assertEquals(
+            PanelFocusTarget.None,
+            resolvePanelFocusTarget(NowPlayingPanel.Lyrics, lyricsAvailable = false),
+        )
     }
 
     @Test

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/PlaybackViewModelTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/PlaybackViewModelTest.kt
@@ -5,7 +5,9 @@ import com.tuneflow.core.player.PlaybackMode
 import com.tuneflow.core.player.PlaybackQueue
 import com.tuneflow.core.player.PlaybackStatus
 import com.tuneflow.core.player.QueueItem
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -133,6 +135,54 @@ class PlaybackViewModelTest {
 
             assertEquals(12_000L, vm.uiState.value.positionMs)
             assertEquals(180_000L, vm.uiState.value.durationMs)
+        }
+
+    @Test
+    fun trackChange_cancelsStaleLyricsAndNeverPublishesOldResult() =
+        runTest {
+            var firstRequestCancelled = false
+            val provider =
+                LyricsProvider { track ->
+                    if (track.id == "1") {
+                        try {
+                            delay(1_000L)
+                            LyricsLoadResult.Available(Lyrics(false, listOf(LyricLine("Old"))))
+                        } catch (error: CancellationException) {
+                            firstRequestCancelled = true
+                            throw error
+                        }
+                    } else {
+                        LyricsLoadResult.Available(Lyrics(false, listOf(LyricLine("New"))))
+                    }
+                }
+            val fake =
+                FakeController(
+                    isPlaying = true,
+                    queue =
+                        PlaybackQueue(
+                            items = listOf(QueueItem("1", "Old", "Artist", "Album", streamUrl = "s")),
+                        ),
+                )
+            val vm =
+                PlaybackViewModel(
+                    playerManager = fake,
+                    lyricsProvider = provider,
+                    positionTicker = flowOf(Unit),
+                    scopeOverride = backgroundScope,
+                )
+            runCurrent()
+
+            fake.updateQueue(
+                PlaybackQueue(
+                    items = listOf(QueueItem("2", "New", "Artist", "Album", streamUrl = "s")),
+                ),
+            )
+            runCurrent()
+
+            val state = vm.lyricsState.value as LyricsUiState.Available
+            assertEquals("2", state.trackId)
+            assertEquals("New", state.lyrics.lines.single().text)
+            assertTrue(firstRequestCancelled)
         }
 }
 


### PR DESCRIPTION
## Summary

- add authenticated OpenSubsonic lyric extension discovery and song-ID lookup with legacy Subsonic fallback
- cache usable and confirmed-empty results while keeping unsupported, network, parsing, and empty states distinct
- add mutually exclusive Track List/Lyrics panels with synchronized highlighting, follow control, remote scrolling, stale-request cancellation, and focus restoration
- cover API parsing, deterministic selection, offsets, seek boundaries, fallback behavior, caching, cancellation, panel behavior, and malformed/error states

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`

Closes #108