### PR TITLE
feat(tv): add playback screensaver idle mode

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -1,11 +1,16 @@
 package com.tuneflow.tv
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
+import android.view.MotionEvent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -29,6 +34,8 @@ import com.tuneflow.feature.auth.LoginScreen
 import com.tuneflow.feature.browse.BrowseRepository
 import com.tuneflow.feature.playback.LyricsRepository
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -38,6 +45,12 @@ class MainActivity : ComponentActivity() {
     private lateinit var playerManager: com.tuneflow.core.player.TvPlayerManager
     private lateinit var playbackServiceIntent: Intent
     private var isAppExitInProgress = false
+    private val userActivityEvents = MutableSharedFlow<UserInputCategory>(extraBufferCapacity = 32)
+    private val wakeConsumedKeyCodes = mutableSetOf<Int>()
+    private var consumeWakeTouchGesture = false
+
+    @Volatile
+    private var screensaverActive = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -76,6 +89,8 @@ class MainActivity : ComponentActivity() {
                         playbackPreferencesStore = playbackPreferencesStore,
                         searchHistoryStore = searchHistoryStore,
                         lyricsRepository = lyricsRepository,
+                        userActivityEvents = userActivityEvents,
+                        onScreensaverActiveChanged = { screensaverActive = it },
                         onExitApp = ::closeAppToSystem,
                     )
                 }
@@ -87,6 +102,89 @@ class MainActivity : ComponentActivity() {
         super.onUserLeaveHint()
         closeAppToSystem()
     }
+
+    @SuppressLint("RestrictedApi")
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        return when {
+            event.keyCode in wakeConsumedKeyCodes -> {
+                if (event.action == KeyEvent.ACTION_UP) {
+                    wakeConsumedKeyCodes.remove(event.keyCode)
+                }
+                true
+            }
+            event.action != KeyEvent.ACTION_DOWN -> super.dispatchKeyEvent(event)
+            else -> {
+                userActivityEvents.tryEmit(classifyUserInput(event.keyCode))
+                when (resolveScreensaverKeyAction(screensaverActive, event.keyCode)) {
+                    ScreensaverKeyAction.RecordAndDispatch -> super.dispatchKeyEvent(event)
+                    ScreensaverKeyAction.WakeAndConsume -> {
+                        screensaverActive = false
+                        wakeConsumedKeyCodes += event.keyCode
+                        true
+                    }
+                    ScreensaverKeyAction.WakeAndDispatchMedia -> {
+                        screensaverActive = false
+                        if (handleScreensaverMediaKey(event.keyCode)) {
+                            wakeConsumedKeyCodes += event.keyCode
+                            true
+                        } else {
+                            super.dispatchKeyEvent(event)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean =
+        when {
+            consumeWakeTouchGesture -> {
+                if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+                    consumeWakeTouchGesture = false
+                }
+                true
+            }
+            event.actionMasked != MotionEvent.ACTION_DOWN -> super.dispatchTouchEvent(event)
+            else -> {
+                userActivityEvents.tryEmit(UserInputCategory.Touch)
+                if (screensaverActive) {
+                    screensaverActive = false
+                    consumeWakeTouchGesture = true
+                    true
+                } else {
+                    super.dispatchTouchEvent(event)
+                }
+            }
+        }
+
+    private fun handleScreensaverMediaKey(keyCode: Int): Boolean =
+        when (resolveMediaPlaybackAction(keyCode)) {
+            MediaPlaybackAction.Toggle -> {
+                if (playerManager.isPlaying.value) playerManager.pause() else playerManager.play()
+                true
+            }
+            MediaPlaybackAction.Play -> {
+                playerManager.play()
+                true
+            }
+            MediaPlaybackAction.Pause -> {
+                playerManager.pause()
+                true
+            }
+            MediaPlaybackAction.Next -> {
+                playerManager.next()
+                true
+            }
+            MediaPlaybackAction.Previous -> {
+                playerManager.previous()
+                true
+            }
+            MediaPlaybackAction.Stop -> {
+                playerManager.stopAndClear()
+                true
+            }
+            MediaPlaybackAction.DispatchToSystem -> false
+        }
 
     private fun closeAppToSystem() {
         if (isAppExitInProgress) return
@@ -162,6 +260,47 @@ private suspend fun cyclePlaybackStreamMode(
 }
 
 @Composable
+private fun rememberPlaybackScreensaverState(
+    playbackState: com.tuneflow.feature.playback.NowPlayingUiState,
+    userActivityEvents: Flow<UserInputCategory>,
+    onActiveChanged: (Boolean) -> Unit,
+): PlaybackScreensaverState {
+    val controller = remember { PlaybackScreensaverController() }
+    val state by controller.state.collectAsStateWithLifecycle()
+    val playbackEligible =
+        playbackState.queue.currentItem != null &&
+            (
+                playbackState.isPlaying ||
+                    (state.active && playbackState.playbackStatus.expectedToPlay)
+            )
+
+    SideEffect {
+        onActiveChanged(state.active)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { onActiveChanged(false) }
+    }
+
+    LaunchedEffect(userActivityEvents) {
+        userActivityEvents.collect { category -> controller.onUserActivity(category) }
+    }
+
+    LaunchedEffect(playbackEligible) {
+        controller.onPlaybackEligibilityChanged(playbackEligible)
+    }
+
+    LaunchedEffect(state.playbackEligible, state.active, state.lastUserActivityMs) {
+        if (state.playbackEligible && !state.active) {
+            delay(controller.remainingDelayMs())
+            controller.onDeadlineReached()
+        }
+    }
+
+    return state
+}
+
+@Composable
 private fun TuneFlowShell(
     browseRepository: BrowseRepository,
     playerManager: com.tuneflow.core.player.TvPlayerManager,
@@ -169,6 +308,8 @@ private fun TuneFlowShell(
     playbackPreferencesStore: PlaybackPreferencesStore,
     searchHistoryStore: SearchHistoryStore,
     lyricsRepository: LyricsRepository,
+    userActivityEvents: Flow<UserInputCategory>,
+    onScreensaverActiveChanged: (Boolean) -> Unit,
     onExitApp: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
@@ -187,6 +328,13 @@ private fun TuneFlowShell(
     val playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel =
         viewModel(factory = playbackViewModelFactory(playerManager, lyricsRepository))
     val playbackState by playbackViewModel.uiState.collectAsStateWithLifecycle()
+    val lyricsState by playbackViewModel.lyricsState.collectAsStateWithLifecycle()
+    val screensaverState =
+        rememberPlaybackScreensaverState(
+            playbackState = playbackState,
+            userActivityEvents = userActivityEvents,
+            onActiveChanged = onScreensaverActiveChanged,
+        )
     val session by sessionStore.sessionFlow.collectAsStateWithLifecycle(initialValue = null)
     val preferDirectWithFallback by playbackPreferencesStore.preferDirectWithFallbackFlow.collectAsStateWithLifecycle(initialValue = false)
     var navWidgetPositionMs by remember { mutableLongStateOf(0L) }
@@ -291,6 +439,8 @@ private fun TuneFlowShell(
         currentTimeText = navClockText,
         playbackQueue = playbackState.queue,
         playbackPositionMs = navWidgetPositionMs,
+        screensaverActive = screensaverState.active,
+        lyricsState = lyricsState,
         homeViewModel = homeViewModel,
         albumsViewModel = albumsViewModel,
         homeCategoryViewModel = homeCategoryViewModel,

--- a/app/src/main/java/com/tuneflow/tv/PlaybackScreensaverController.kt
+++ b/app/src/main/java/com/tuneflow/tv/PlaybackScreensaverController.kt
@@ -1,0 +1,88 @@
+package com.tuneflow.tv
+
+import android.os.SystemClock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal const val PLAYBACK_SCREENSAVER_TIMEOUT_MS = 60_000L
+
+internal fun interface MonotonicClock {
+    fun nowMs(): Long
+}
+
+internal object SystemMonotonicClock : MonotonicClock {
+    override fun nowMs(): Long = SystemClock.elapsedRealtime()
+}
+
+internal data class PlaybackScreensaverState(
+    val lastUserActivityMs: Long,
+    val playbackEligible: Boolean = false,
+    val active: Boolean = false,
+)
+
+internal sealed interface PlaybackScreensaverEvent {
+    data class UserActivity(val category: UserInputCategory) : PlaybackScreensaverEvent
+
+    data class PlaybackEligibilityChanged(val eligible: Boolean) : PlaybackScreensaverEvent
+
+    data object DeadlineReached : PlaybackScreensaverEvent
+}
+
+internal fun reducePlaybackScreensaverState(
+    state: PlaybackScreensaverState,
+    event: PlaybackScreensaverEvent,
+    nowMs: Long,
+    timeoutMs: Long = PLAYBACK_SCREENSAVER_TIMEOUT_MS,
+): PlaybackScreensaverState =
+    when (event) {
+        is PlaybackScreensaverEvent.UserActivity ->
+            state.copy(lastUserActivityMs = nowMs, active = false)
+        is PlaybackScreensaverEvent.PlaybackEligibilityChanged -> {
+            when {
+                !event.eligible ->
+                    state.copy(
+                        lastUserActivityMs = nowMs,
+                        playbackEligible = false,
+                        active = false,
+                    )
+                !state.playbackEligible ->
+                    state.copy(
+                        lastUserActivityMs = nowMs,
+                        playbackEligible = true,
+                        active = false,
+                    )
+                else -> state
+            }
+        }
+        PlaybackScreensaverEvent.DeadlineReached -> {
+            val idleLongEnough = nowMs - state.lastUserActivityMs >= timeoutMs
+            state.copy(active = state.playbackEligible && idleLongEnough)
+        }
+    }
+
+internal class PlaybackScreensaverController(
+    private val clock: MonotonicClock = SystemMonotonicClock,
+    private val timeoutMs: Long = PLAYBACK_SCREENSAVER_TIMEOUT_MS,
+) {
+    private val _state = MutableStateFlow(PlaybackScreensaverState(lastUserActivityMs = clock.nowMs()))
+    val state: StateFlow<PlaybackScreensaverState> = _state.asStateFlow()
+
+    fun onUserActivity(category: UserInputCategory) {
+        update(PlaybackScreensaverEvent.UserActivity(category))
+    }
+
+    fun onPlaybackEligibilityChanged(eligible: Boolean) {
+        update(PlaybackScreensaverEvent.PlaybackEligibilityChanged(eligible))
+    }
+
+    fun onDeadlineReached() {
+        update(PlaybackScreensaverEvent.DeadlineReached)
+    }
+
+    fun remainingDelayMs(): Long = (timeoutMs - (clock.nowMs() - state.value.lastUserActivityMs)).coerceAtLeast(0L)
+
+    private fun update(event: PlaybackScreensaverEvent) {
+        _state.value = reducePlaybackScreensaverState(_state.value, event, clock.nowMs(), timeoutMs)
+    }
+}

--- a/app/src/main/java/com/tuneflow/tv/ScreensaverInputPolicy.kt
+++ b/app/src/main/java/com/tuneflow/tv/ScreensaverInputPolicy.kt
@@ -1,0 +1,77 @@
+package com.tuneflow.tv
+
+import android.view.KeyEvent
+
+internal enum class UserInputCategory {
+    Navigation,
+    Back,
+    Select,
+    Media,
+    Keyboard,
+    Touch,
+}
+
+internal enum class ScreensaverKeyAction {
+    RecordAndDispatch,
+    WakeAndConsume,
+    WakeAndDispatchMedia,
+}
+
+internal enum class MediaPlaybackAction {
+    Toggle,
+    Play,
+    Pause,
+    Next,
+    Previous,
+    Stop,
+    DispatchToSystem,
+}
+
+internal fun resolveScreensaverKeyAction(
+    screensaverActive: Boolean,
+    keyCode: Int,
+): ScreensaverKeyAction =
+    when {
+        !screensaverActive -> ScreensaverKeyAction.RecordAndDispatch
+        isMediaKey(keyCode) -> ScreensaverKeyAction.WakeAndDispatchMedia
+        else -> ScreensaverKeyAction.WakeAndConsume
+    }
+
+internal fun classifyUserInput(keyCode: Int): UserInputCategory =
+    when (keyCode) {
+        KeyEvent.KEYCODE_DPAD_UP,
+        KeyEvent.KEYCODE_DPAD_DOWN,
+        KeyEvent.KEYCODE_DPAD_LEFT,
+        KeyEvent.KEYCODE_DPAD_RIGHT,
+        -> UserInputCategory.Navigation
+        KeyEvent.KEYCODE_BACK -> UserInputCategory.Back
+        KeyEvent.KEYCODE_DPAD_CENTER,
+        KeyEvent.KEYCODE_ENTER,
+        KeyEvent.KEYCODE_NUMPAD_ENTER,
+        -> UserInputCategory.Select
+        else -> if (isMediaKey(keyCode)) UserInputCategory.Media else UserInputCategory.Keyboard
+    }
+
+internal fun isMediaKey(keyCode: Int): Boolean =
+    keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_PLAY ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_PAUSE ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_NEXT ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_STOP ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD ||
+        keyCode == KeyEvent.KEYCODE_MEDIA_REWIND ||
+        keyCode == KeyEvent.KEYCODE_HEADSETHOOK
+
+internal fun resolveMediaPlaybackAction(keyCode: Int): MediaPlaybackAction =
+    when (keyCode) {
+        KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+        KeyEvent.KEYCODE_HEADSETHOOK,
+        -> MediaPlaybackAction.Toggle
+        KeyEvent.KEYCODE_MEDIA_PLAY -> MediaPlaybackAction.Play
+        KeyEvent.KEYCODE_MEDIA_PAUSE -> MediaPlaybackAction.Pause
+        KeyEvent.KEYCODE_MEDIA_NEXT -> MediaPlaybackAction.Next
+        KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaPlaybackAction.Previous
+        KeyEvent.KEYCODE_MEDIA_STOP -> MediaPlaybackAction.Stop
+        else -> MediaPlaybackAction.DispatchToSystem
+    }

--- a/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
+++ b/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -42,6 +43,9 @@ import androidx.compose.ui.unit.dp
 import com.tuneflow.core.design.TuneFlowArtwork
 import com.tuneflow.core.network.ScreenScaleOption
 import com.tuneflow.core.player.PlaybackQueue
+import com.tuneflow.feature.playback.Lyrics
+import com.tuneflow.feature.playback.LyricsRenderer
+import com.tuneflow.feature.playback.LyricsUiState
 
 @Composable
 internal fun TuneFlowShellLayout(
@@ -52,6 +56,8 @@ internal fun TuneFlowShellLayout(
     currentTimeText: String,
     playbackQueue: PlaybackQueue,
     playbackPositionMs: Long,
+    screensaverActive: Boolean,
+    lyricsState: LyricsUiState,
     homeViewModel: HomeViewModel,
     albumsViewModel: com.tuneflow.feature.browse.AlbumsViewModel,
     homeCategoryViewModel: com.tuneflow.feature.browse.HomeCategoryViewModel,
@@ -185,6 +191,14 @@ internal fun TuneFlowShellLayout(
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 28.dp),
         )
+
+        if (screensaverActive) {
+            PlaybackScreensaverOverlay(
+                playbackQueue = playbackQueue,
+                playbackPositionMs = playbackPositionMs,
+                lyricsState = lyricsState,
+            )
+        }
     }
 }
 
@@ -271,6 +285,7 @@ private fun NavRail(
             playbackPositionMs = playbackPositionMs,
             selected = isNowPlayingActive,
             onClick = onNowPlaying,
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -323,14 +338,16 @@ private fun NavRailItem(
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
-private fun NowPlayingRailWidget(
+internal fun NowPlayingRailWidget(
     playbackQueue: PlaybackQueue,
     playbackPositionMs: Long,
     selected: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    interactive: Boolean = true,
 ) {
     var focused by remember { mutableStateOf(false) }
-    val active = selected || focused
+    val active = interactive && (selected || focused)
     val currentItem = playbackQueue.currentItem
     val durationMs = currentItem?.durationMs ?: 0L
     val positionMs = playbackPositionMs.coerceAtLeast(0L)
@@ -343,11 +360,17 @@ private fun NowPlayingRailWidget(
 
     Box(
         modifier =
-            Modifier
-                .fillMaxWidth()
+            modifier
                 .height(196.dp)
-                .onFocusChanged { focusState -> focused = focusState.isFocused }
-                .focusable()
+                .then(
+                    if (interactive) {
+                        Modifier
+                            .onFocusChanged { focusState -> focused = focusState.isFocused }
+                            .focusable()
+                    } else {
+                        Modifier
+                    },
+                )
                 .clip(RoundedCornerShape(22.dp))
                 .background(
                     if (active) {
@@ -366,7 +389,7 @@ private fun NowPlayingRailWidget(
                         },
                     shape = RoundedCornerShape(22.dp),
                 )
-                .clickable(onClick = onClick)
+                .then(if (interactive) Modifier.clickable(onClick = onClick) else Modifier)
                 .padding(10.dp),
     ) {
         Column(
@@ -429,7 +452,7 @@ private fun NowPlayingRailWidget(
                 trackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.48f),
             )
             Text(
-                text = railFormatTime(positionMs),
+                text = "${railFormatTime(positionMs)} / ${railFormatTime(durationMs)}",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -438,6 +461,92 @@ private fun NowPlayingRailWidget(
         }
     }
 }
+
+@Composable
+private fun PlaybackScreensaverOverlay(
+    playbackQueue: PlaybackQueue,
+    playbackPositionMs: Long,
+    lyricsState: LyricsUiState,
+) {
+    val currentItem = playbackQueue.currentItem ?: return
+    val lyrics = resolveScreensaverLyrics(lyricsState, currentItem.id)
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black),
+    ) {
+        TuneFlowArtwork(
+            model = currentItem.artUrl,
+            contentDescription = null,
+            width = 1280.dp,
+            height = 720.dp,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+            alpha = 0.42f,
+            placeholderText = currentItem.title,
+            fallbackPainterResId = R.drawable.ic_tuneflow_brand,
+        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.58f)),
+        )
+
+        NowPlayingRailWidget(
+            playbackQueue = playbackQueue,
+            playbackPositionMs = playbackPositionMs,
+            selected = false,
+            onClick = {},
+            modifier =
+                Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 44.dp, bottom = 40.dp)
+                    .width(190.dp),
+            interactive = false,
+        )
+
+        if (lyrics != null) {
+            Column(
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(vertical = 52.dp, horizontal = 64.dp)
+                        .width(430.dp)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(28.dp))
+                        .background(Color.Black.copy(alpha = 0.34f))
+                        .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = "Lyrics",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                LyricsRenderer(
+                    lyrics = lyrics,
+                    positionMs = playbackPositionMs,
+                    durationMs = currentItem.durationMs,
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    autoFollow = true,
+                    interactive = false,
+                    estimateUnsynchronized = true,
+                )
+            }
+        }
+    }
+}
+
+internal fun resolveScreensaverLyrics(
+    lyricsState: LyricsUiState,
+    currentTrackId: String,
+): Lyrics? =
+    (lyricsState as? LyricsUiState.Available)
+        ?.takeIf { it.trackId == currentTrackId }
+        ?.lyrics
 
 private fun railFormatTime(ms: Long): String {
     if (ms <= 0L) return "00:00"

--- a/app/src/test/java/com/tuneflow/tv/PlaybackScreensaverControllerTest.kt
+++ b/app/src/test/java/com/tuneflow/tv/PlaybackScreensaverControllerTest.kt
@@ -1,0 +1,97 @@
+package com.tuneflow.tv
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackScreensaverControllerTest {
+    @Test
+    fun entersExactlyAtSixtySecondsOnlyWhenPlaybackEligible() {
+        val clock = FakeMonotonicClock()
+        val controller = PlaybackScreensaverController(clock)
+        controller.onPlaybackEligibilityChanged(true)
+
+        clock.now = 59_999L
+        controller.onDeadlineReached()
+        assertFalse(controller.state.value.active)
+
+        clock.now = 60_000L
+        controller.onDeadlineReached()
+        assertTrue(controller.state.value.active)
+
+        controller.onPlaybackEligibilityChanged(false)
+        clock.now = 120_000L
+        controller.onDeadlineReached()
+        assertFalse(controller.state.value.active)
+    }
+
+    @Test
+    fun eachInputCategoryResetsTimerAndDismissesImmediately() {
+        UserInputCategory.entries.forEach { category ->
+            val clock = FakeMonotonicClock()
+            val controller = PlaybackScreensaverController(clock)
+            controller.onPlaybackEligibilityChanged(true)
+            clock.now = 60_000L
+            controller.onDeadlineReached()
+            assertTrue(controller.state.value.active)
+
+            clock.now += 1L
+            controller.onUserActivity(category)
+
+            assertFalse(controller.state.value.active)
+            assertEquals(clock.now, controller.state.value.lastUserActivityMs)
+        }
+    }
+
+    @Test
+    fun playbackUpdatesAndAutomaticTrackChangesDoNotResetTimer() {
+        val clock = FakeMonotonicClock()
+        val controller = PlaybackScreensaverController(clock)
+        controller.onPlaybackEligibilityChanged(true)
+        val startedAt = controller.state.value.lastUserActivityMs
+
+        clock.now = 30_000L
+        controller.onPlaybackEligibilityChanged(true)
+        assertEquals(startedAt, controller.state.value.lastUserActivityMs)
+
+        clock.now = 60_000L
+        controller.onDeadlineReached()
+        assertTrue(controller.state.value.active)
+
+        clock.now = 61_000L
+        controller.onPlaybackEligibilityChanged(true)
+        assertTrue(controller.state.value.active)
+        assertEquals(startedAt, controller.state.value.lastUserActivityMs)
+    }
+
+    @Test
+    fun pauseStopSignOutOrEmptyQueueDismissesImmediately() {
+        val clock = FakeMonotonicClock()
+        val controller = PlaybackScreensaverController(clock)
+
+        repeat(4) {
+            controller.onPlaybackEligibilityChanged(true)
+            clock.now += 60_000L
+            controller.onDeadlineReached()
+            assertTrue(controller.state.value.active)
+
+            controller.onPlaybackEligibilityChanged(false)
+            assertFalse(controller.state.value.active)
+        }
+    }
+
+    @Test
+    fun remainingDelayUsesMonotonicTime() {
+        val clock = FakeMonotonicClock(now = 10_000L)
+        val controller = PlaybackScreensaverController(clock)
+        controller.onPlaybackEligibilityChanged(true)
+        clock.now = 35_000L
+
+        assertEquals(35_000L, controller.remainingDelayMs())
+    }
+}
+
+private class FakeMonotonicClock(var now: Long = 0L) : MonotonicClock {
+    override fun nowMs(): Long = now
+}

--- a/app/src/test/java/com/tuneflow/tv/PlaybackScreensaverPresentationTest.kt
+++ b/app/src/test/java/com/tuneflow/tv/PlaybackScreensaverPresentationTest.kt
@@ -1,0 +1,20 @@
+package com.tuneflow.tv
+
+import com.tuneflow.feature.playback.LyricLine
+import com.tuneflow.feature.playback.Lyrics
+import com.tuneflow.feature.playback.LyricsUiState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PlaybackScreensaverPresentationTest {
+    @Test
+    fun lyricsOnlyResolveForCurrentTrack() {
+        val lyrics = Lyrics(synchronized = false, lines = listOf(LyricLine("Line")))
+        val state = LyricsUiState.Available(trackId = "one", lyrics = lyrics)
+
+        assertEquals(lyrics, resolveScreensaverLyrics(state, "one"))
+        assertNull(resolveScreensaverLyrics(state, "two"))
+        assertNull(resolveScreensaverLyrics(LyricsUiState.Empty("one"), "one"))
+    }
+}

--- a/app/src/test/java/com/tuneflow/tv/ScreensaverInputPolicyTest.kt
+++ b/app/src/test/java/com/tuneflow/tv/ScreensaverInputPolicyTest.kt
@@ -1,0 +1,55 @@
+package com.tuneflow.tv
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreensaverInputPolicyTest {
+    @Test
+    fun firstNavigationSelectBackAndKeyboardWakeEventIsConsumed() {
+        listOf(
+            KeyEvent.KEYCODE_DPAD_UP,
+            KeyEvent.KEYCODE_DPAD_CENTER,
+            KeyEvent.KEYCODE_BACK,
+            KeyEvent.KEYCODE_A,
+        ).forEach { keyCode ->
+            assertEquals(
+                ScreensaverKeyAction.WakeAndConsume,
+                resolveScreensaverKeyAction(screensaverActive = true, keyCode = keyCode),
+            )
+        }
+    }
+
+    @Test
+    fun mediaWakeEventStillDispatchesPlaybackAction() {
+        assertEquals(
+            ScreensaverKeyAction.WakeAndDispatchMedia,
+            resolveScreensaverKeyAction(true, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE),
+        )
+        assertEquals(MediaPlaybackAction.Toggle, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE))
+        assertEquals(MediaPlaybackAction.Play, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_PLAY))
+        assertEquals(MediaPlaybackAction.Pause, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_PAUSE))
+        assertEquals(MediaPlaybackAction.Next, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_NEXT))
+        assertEquals(MediaPlaybackAction.Previous, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_PREVIOUS))
+        assertEquals(MediaPlaybackAction.Stop, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_STOP))
+        assertEquals(MediaPlaybackAction.DispatchToSystem, resolveMediaPlaybackAction(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD))
+    }
+
+    @Test
+    fun inactiveScreensaverRecordsWithoutConsuming() {
+        assertEquals(
+            ScreensaverKeyAction.RecordAndDispatch,
+            resolveScreensaverKeyAction(false, KeyEvent.KEYCODE_DPAD_DOWN),
+        )
+    }
+
+    @Test
+    fun inputCategoriesCoverRemoteMediaKeyboardAndTouch() {
+        assertEquals(UserInputCategory.Navigation, classifyUserInput(KeyEvent.KEYCODE_DPAD_LEFT))
+        assertEquals(UserInputCategory.Back, classifyUserInput(KeyEvent.KEYCODE_BACK))
+        assertEquals(UserInputCategory.Select, classifyUserInput(KeyEvent.KEYCODE_ENTER))
+        assertEquals(UserInputCategory.Media, classifyUserInput(KeyEvent.KEYCODE_MEDIA_NEXT))
+        assertEquals(UserInputCategory.Keyboard, classifyUserInput(KeyEvent.KEYCODE_A))
+        assertEquals(UserInputCategory.Touch, UserInputCategory.Touch)
+    }
+}

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/LyricsTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/LyricsTest.kt
@@ -75,6 +75,15 @@ class LyricsTest {
         assertEquals(0, resolveActiveLyricLine(lyrics, 1_200L))
     }
 
+    @Test
+    fun unsynchronizedEstimate_clampsProgressAndProtectsUnknownDuration() {
+        assertEquals(0, estimateActiveLyricLine(lineCount = 5, positionMs = -1L, durationMs = 100_000L))
+        assertEquals(2, estimateActiveLyricLine(lineCount = 5, positionMs = 50_000L, durationMs = 100_000L))
+        assertEquals(4, estimateActiveLyricLine(lineCount = 5, positionMs = 200_000L, durationMs = 100_000L))
+        assertNull(estimateActiveLyricLine(lineCount = 5, positionMs = 10_000L, durationMs = 0L))
+        assertNull(estimateActiveLyricLine(lineCount = 0, positionMs = 10_000L, durationMs = 100_000L))
+    }
+
     private fun structured(
         kind: String?,
         synced: Boolean,


### PR DESCRIPTION
## Summary

- Add a 60-second monotonic idle controller scoped to active playback.
- Capture remote, keyboard, media-key, and touch activity at activity level with safe wake-event consumption.
- Render dark album art, a passive live Now Playing widget, and optional synchronized or estimated lyrics without changing navigation state.
- Preserve the overlay across automatic track changes and dismiss it immediately when playback becomes ineligible.

## Stack

- Depends on #110.
- Base branch: `feat/issue-108-lyrics`.

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`
- Fake-time idle controller, input-policy, lyric-selection, and unsynchronized progress tests.

## Device verification

A connected Fire TV was detected and the debug APK built successfully. Installation was blocked because the installed `com.tuneflow.tv` uses a different signing key. The existing app and its data were left untouched.

Closes #109