### PR TITLE
ui: standardize tight corner radii across TV surfaces

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/ExitPromptBanner.kt
+++ b/app/src/main/java/com/tuneflow/tv/ExitPromptBanner.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.tuneflow.core.design.TuneFlowShapes
 
 @Composable
 internal fun ExitPromptBanner(
@@ -32,12 +32,12 @@ internal fun ExitPromptBanner(
         Box(
             modifier =
                 Modifier
-                    .clip(RoundedCornerShape(18.dp))
+                    .clip(TuneFlowShapes.panel)
                     .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.94f))
                     .border(
                         width = 1.dp,
                         color = MaterialTheme.colorScheme.outline.copy(alpha = 0.22f),
-                        shape = RoundedCornerShape(18.dp),
+                        shape = TuneFlowShapes.panel,
                     )
                     .padding(horizontal = 18.dp, vertical = 12.dp),
         ) {

--- a/app/src/main/java/com/tuneflow/tv/HomeScreen.kt
+++ b/app/src/main/java/com/tuneflow/tv/HomeScreen.kt
@@ -437,7 +437,7 @@ private fun HomeHero(
             Modifier
                 .fillMaxWidth()
                 .height(246.dp)
-                .clip(TuneFlowShapes.hero)
+                .clip(TuneFlowShapes.container)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.82f)),
     ) {
         if (currentItem?.artUrl != null) {
@@ -514,7 +514,7 @@ private fun HomeHero(
                 modifier =
                     Modifier
                         .size(168.dp)
-                        .clip(TuneFlowShapes.albumArt)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.78f)),
                 contentAlignment = Alignment.Center,
             ) {
@@ -667,7 +667,7 @@ private fun FavoriteTrackCard(
                     Modifier
                         .fillMaxWidth()
                         .height(196.dp)
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
             ) {
                 TuneFlowArtwork(
@@ -714,7 +714,7 @@ private fun HomeArtistCard(
                     Modifier
                         .fillMaxWidth()
                         .height(172.dp)
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
             ) {
                 TuneFlowArtwork(
@@ -754,7 +754,7 @@ private fun AlbumCardSkeleton() {
                 Modifier
                     .fillMaxWidth()
                     .height(196.dp)
-                    .clip(TuneFlowShapes.card)
+                    .clip(TuneFlowShapes.artwork)
                     .shimmerEffect(),
         )
         Box(
@@ -791,7 +791,7 @@ private fun ErrorBanner(message: String) {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.panel)
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f))
                 .padding(28.dp),
     ) {
@@ -830,7 +830,7 @@ private fun HomeAlbumCard(
                     Modifier
                         .fillMaxWidth()
                         .height(196.dp)
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
             ) {
                 TuneFlowArtwork(
@@ -911,7 +911,7 @@ private fun PlaylistArtCollage(playlist: PlaylistSummary) {
             Modifier
                 .fillMaxWidth()
                 .height(120.dp)
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.artwork)
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.92f)),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {

--- a/app/src/main/java/com/tuneflow/tv/Theme.kt
+++ b/app/src/main/java/com/tuneflow/tv/Theme.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.tuneflow.core.design.TuneFlowShapes
 
 private val TuneFlowDarkScheme =
     darkColorScheme(
@@ -125,6 +126,7 @@ fun TuneFlowTheme(content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = TuneFlowDarkScheme,
         typography = TuneFlowTypography,
+        shapes = TuneFlowShapes.material,
         content = content,
     )
 }

--- a/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
+++ b/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -41,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.tuneflow.core.design.TuneFlowArtwork
+import com.tuneflow.core.design.TuneFlowShapes
 import com.tuneflow.core.network.ScreenScaleOption
 import com.tuneflow.core.player.PlaybackQueue
 import com.tuneflow.feature.playback.Lyrics
@@ -119,12 +118,12 @@ internal fun TuneFlowShellLayout(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .clip(RoundedCornerShape(34.dp))
+                        .clip(TuneFlowShapes.surface)
                         .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.78f))
                         .border(
                             width = 1.dp,
                             color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f),
-                            shape = RoundedCornerShape(34.dp),
+                            shape = TuneFlowShapes.surface,
                         ),
             ) {
                 TuneFlowScaledContent(scaleFactor = ScreenScaleOption.Compact.factor) {
@@ -218,12 +217,12 @@ private fun NavRail(
             Modifier
                 .width(148.dp)
                 .fillMaxHeight()
-                .clip(RoundedCornerShape(28.dp))
+                .clip(TuneFlowShapes.container)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.82f))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.22f),
-                    shape = RoundedCornerShape(28.dp),
+                    shape = TuneFlowShapes.container,
                 )
                 .padding(vertical = 20.dp, horizontal = 10.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -238,9 +237,13 @@ private fun NavRail(
                 modifier =
                     Modifier
                         .size(52.dp)
-                        .clip(CircleShape)
+                        .clip(TuneFlowShapes.avatar)
                         .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.22f))
-                        .border(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.35f), CircleShape),
+                        .border(
+                            1.dp,
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.35f),
+                            TuneFlowShapes.avatar,
+                        ),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -305,7 +308,7 @@ private fun NavRailItem(
                 .fillMaxWidth()
                 .onFocusChanged { focusState -> focused = focusState.isFocused }
                 .focusable()
-                .clip(RoundedCornerShape(20.dp))
+                .clip(TuneFlowShapes.row)
                 .background(
                     if (active) {
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.34f)
@@ -321,7 +324,7 @@ private fun NavRailItem(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.16f)
                         },
-                    shape = RoundedCornerShape(20.dp),
+                    shape = TuneFlowShapes.row,
                 )
                 .clickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 16.dp),
@@ -371,7 +374,7 @@ internal fun NowPlayingRailWidget(
                         Modifier
                     },
                 )
-                .clip(RoundedCornerShape(22.dp))
+                .clip(TuneFlowShapes.card)
                 .background(
                     if (active) {
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.24f)
@@ -387,7 +390,7 @@ internal fun NowPlayingRailWidget(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
                         },
-                    shape = RoundedCornerShape(22.dp),
+                    shape = TuneFlowShapes.card,
                 )
                 .then(if (interactive) Modifier.clickable(onClick = onClick) else Modifier)
                 .padding(10.dp),
@@ -409,7 +412,7 @@ internal fun NowPlayingRailWidget(
                     Modifier
                         .fillMaxWidth()
                         .height(84.dp)
-                        .clip(RoundedCornerShape(16.dp))
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.72f)),
                 contentAlignment = Alignment.Center,
             ) {
@@ -448,7 +451,7 @@ internal fun NowPlayingRailWidget(
                     Modifier
                         .fillMaxWidth()
                         .height(4.dp)
-                        .clip(RoundedCornerShape(999.dp)),
+                        .clip(TuneFlowShapes.progressTrack),
                 trackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.48f),
             )
             Text(
@@ -516,7 +519,7 @@ private fun PlaybackScreensaverOverlay(
                         .padding(vertical = 52.dp, horizontal = 64.dp)
                         .width(430.dp)
                         .fillMaxHeight()
-                        .clip(RoundedCornerShape(28.dp))
+                        .clip(TuneFlowShapes.panel)
                         .background(Color.Black.copy(alpha = 0.34f))
                         .padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/core/design/build.gradle.kts
+++ b/core/design/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     implementation("androidx.compose.foundation:foundation:1.6.8")
     implementation("androidx.compose.material3:material3:1.2.1")
     implementation("io.coil-kt:coil-compose:2.7.0")
+
+    testImplementation("junit:junit:4.13.2")
 }
 
 detekt {

--- a/core/design/src/main/java/com/tuneflow/core/design/TuneFlowShapes.kt
+++ b/core/design/src/main/java/com/tuneflow/core/design/TuneFlowShapes.kt
@@ -1,14 +1,33 @@
 package com.tuneflow.core.design
 
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
 object TuneFlowShapes {
-    val card = RoundedCornerShape(8.dp)
-    val button = RoundedCornerShape(8.dp)
-    val row = RoundedCornerShape(4.dp)
-    val hero = RoundedCornerShape(12.dp)
-    val albumArt = RoundedCornerShape(12.dp)
-    val badge = RoundedCornerShape(8.dp)
-    val field = RoundedCornerShape(8.dp)
+    private val tightRectangle = RoundedCornerShape(8.dp)
+
+    val surface = tightRectangle
+    val container = tightRectangle
+    val card = tightRectangle
+    val button = tightRectangle
+    val row = tightRectangle
+    val field = tightRectangle
+    val panel = tightRectangle
+    val badge = tightRectangle
+    val artwork = tightRectangle
+
+    val avatar = CircleShape
+    val iconButton = CircleShape
+    val progressTrack = CircleShape
+
+    val material =
+        Shapes(
+            extraSmall = badge,
+            small = button,
+            medium = card,
+            large = container,
+            extraLarge = surface,
+        )
 }

--- a/core/design/src/test/java/com/tuneflow/core/design/TuneFlowShapesTest.kt
+++ b/core/design/src/test/java/com/tuneflow/core/design/TuneFlowShapesTest.kt
@@ -1,0 +1,33 @@
+package com.tuneflow.core.design
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TuneFlowShapesTest {
+    @Test
+    fun rectangularTokensUseApprovedTightRadius() {
+        val expected = RoundedCornerShape(8.dp)
+
+        listOf(
+            TuneFlowShapes.surface,
+            TuneFlowShapes.container,
+            TuneFlowShapes.card,
+            TuneFlowShapes.button,
+            TuneFlowShapes.row,
+            TuneFlowShapes.field,
+            TuneFlowShapes.panel,
+            TuneFlowShapes.badge,
+            TuneFlowShapes.artwork,
+        ).forEach { shape -> assertEquals(expected, shape) }
+    }
+
+    @Test
+    fun documentedExceptionsRemainCircular() {
+        assertEquals(CircleShape, TuneFlowShapes.avatar)
+        assertEquals(CircleShape, TuneFlowShapes.iconButton)
+        assertEquals(CircleShape, TuneFlowShapes.progressTrack)
+    }
+}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,6 +1,6 @@
 # TuneFlow Design System
 ### Android TV / Fire TV — 10-Foot UI Guidelines
-> **Version:** 1.1 · **Platform:** Android TV (API 21+) · **Input:** D-pad remote only
+> **Version:** 1.2 · **Platform:** Android TV (API 21+) · **Input:** D-pad remote only
 
 ---
 
@@ -168,10 +168,10 @@ All content must be inset from screen edges to account for TV overscan and bezel
 | Card Type | Width | Height | Image Ratio | Corner Radius |
 |---|---|---|---|---|
 | Album card | 200dp | 240dp | 1:1 (square) | 8dp |
-| Artist card | 180dp | 220dp | 1:1 (circle) | 50% |
+| Artist card | 180dp | 220dp | 1:1 (square) | 8dp |
 | Playlist card | 200dp | 240dp | 1:1 (square) | 8dp |
-| Track row | Full width | 72dp | 1:1 (56dp thumb) | 4dp |
-| Featured hero | Full content width | 320dp | 16:9 | 12dp |
+| Track row | Full width | 72dp | 1:1 (56dp thumb) | 8dp |
+| Featured hero | Full content width | 320dp | 16:9 | 8dp |
 
 ---
 
@@ -378,14 +378,14 @@ All colors are defined for **dark theme only**. TuneFlow does not support a ligh
 
 ```
 ┌─────────────────────┐
-│                     │  ← Image: 180×180dp, circular (50% radius)
+│                     │  ← Image: 180×180dp, 8dp corner radius
 │    [Artist Photo]   │
 │                     │
 └─────────────────────┘
       Artist Name      ← typography.titleSmall, color.onSurface, centered, maxLines=1
 ```
 
-**Focus state:** Same as Album Card but applied to the circular image.
+**Focus state:** Same as Album Card and aligned to the 8dp artwork edge.
 
 ---
 
@@ -404,7 +404,7 @@ All colors are defined for **dark theme only**. TuneFlow does not support a ligh
 | Column | Width | Content |
 |---|---|---|
 | Track number | 40dp | `typography.caption`, `color.textDisabled`, right-aligned |
-| Thumbnail | 56dp | Square, 4dp corner radius |
+| Thumbnail | 56dp | Square, 8dp corner radius |
 | Title + metadata | Flexible (fill) | Title: `typography.bodyLarge`; Subtitle: `typography.bodyMedium` `color.textSecondary` |
 | Duration | 64dp | `typography.caption`, `color.textSecondary`, right-aligned |
 | Overflow menu | 40dp | 3-dot icon, only visible when row is focused |
@@ -451,7 +451,7 @@ All colors are defined for **dark theme only**. TuneFlow does not support a ligh
 - Icon: 24dp, centered at 36dp from left edge
 - Label: 16dp left of icon right edge
 - Padding: 16dp horizontal (expanded), 24dp horizontal (collapsed, icon centered)
-- Corner radius: 8dp (right side only, for selected state pill)
+- Corner radius: 8dp on all corners
 
 **States:**
 
@@ -660,7 +660,7 @@ Sort bar: Top of content area, horizontal list of sort options (A-Z, Year, Artis
 - Focus wraps: No horizontal wrap; D-pad Left on column 1 → sidebar
 
 **Sort bar:**
-- Items: Chips (pill-shaped), height 36dp, 16dp horizontal padding
+- Items: Chips with 8dp corners, height 36dp, 16dp horizontal padding
 - Selected chip: `color.primary` background, `color.textOnPrimary` text
 - Unselected chip: `color.surfaceVariant` background, `color.textSecondary` text
 - Focus: 2dp `color.focusBorder` border, 1.05× scale
@@ -738,7 +738,7 @@ Track list: Same as Album Detail track list
 **Background treatment:**
 - Full-screen blurred album art: `blur radius = 40dp`, `brightness = 0.3`
 - Overlay: `color.background` at 60% opacity on top of blur
-- Album art: 480×480dp, centered-left, 12dp corner radius, elevation shadow
+- Album art: 480×480dp, centered-left, 8dp corner radius, elevation shadow
 
 **Controls layout:**
 - Primary controls (prev/play/next): 72dp icon buttons, 32dp gap
@@ -956,7 +956,7 @@ IconButton(onClick = { /* ... */ }) {
 object TuneFlowTheme {
     val colors: TuneFlowColors = TuneFlowColors()
     val typography: TuneFlowTypography = TuneFlowTypography()
-    val shapes: TuneFlowShapes = TuneFlowShapes()
+    val shapes = TuneFlowShapes
     val spacing: TuneFlowSpacing = TuneFlowSpacing()
     val motion: TuneFlowMotion = TuneFlowMotion()
 }
@@ -1021,7 +1021,31 @@ data class TuneFlowTypography(
 )
 ```
 
-### 13.4 Spacing Tokens
+### 13.4 Shape Tokens
+
+`TuneFlowShapes` in `core/design` is the only source of truth for component shapes.
+Every rectangular surface uses the approved 8dp radius.
+
+| Token | Radius | Usage |
+|---|---:|---|
+| `surface` | 8dp | Root shell surfaces |
+| `container` | 8dp | Navigation and large content containers |
+| `card` | 8dp | Content cards and card states |
+| `button` | 8dp | Text and action buttons |
+| `row` | 8dp | Navigation, track, queue, and lyric rows |
+| `field` | 8dp | Editable fields and display-field states |
+| `panel` | 8dp | Detail, queue, lyric, loading, empty, and error panels |
+| `badge` | 8dp | Badges and compact status surfaces |
+| `artwork` | 8dp | Rectangular artwork and placeholders |
+
+Documented exceptions:
+
+- `avatar` and `iconButton` remain circular because their shape communicates identity or control type.
+- `progressTrack` remains pill-shaped because its shape communicates progress.
+- No other container, chip, selected state, loading state, or placeholder may use pill or ad hoc corner shapes.
+- `clip`, `background`, `border`, focus, selected, pressed, loading, empty, and error states must share their component token.
+
+### 13.5 Spacing Tokens
 
 ```kotlin
 data class TuneFlowSpacing(
@@ -1037,7 +1061,7 @@ data class TuneFlowSpacing(
 )
 ```
 
-### 13.5 Motion Tokens
+### 13.6 Motion Tokens
 
 ```kotlin
 data class TuneFlowMotion(
@@ -1052,7 +1076,7 @@ data class TuneFlowMotion(
 )
 ```
 
-### 13.6 Focus Modifier Pattern
+### 13.7 Focus Modifier Pattern
 
 ```kotlin
 // Reusable focus modifier for cards
@@ -1074,13 +1098,13 @@ fun Modifier.tuneFlowFocusCard(
             if (isFocused) Modifier.border(
                 width = motion.focusBorderWidth,
                 color = colors.focusBorder,
-                shape = RoundedCornerShape(8.dp)
+                shape = TuneFlowShapes.card
             ) else Modifier
         )
 }
 ```
 
-### 13.7 Naming Conventions
+### 13.8 Naming Conventions
 
 | Element | Convention | Example |
 |---|---|---|

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -33,6 +33,7 @@ android {
 
 dependencies {
     implementation(project(":core:network"))
+    implementation(project(":core:design"))
 
     implementation("androidx.compose.ui:ui:1.6.8")
     implementation("androidx.compose.material3:material3:1.2.1")

--- a/feature/auth/src/main/java/com/tuneflow/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/tuneflow/feature/auth/LoginScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -59,6 +58,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tuneflow.core.design.TuneFlowShapes
 
 private enum class LoginFieldKey { ServerUrl, Username, Password }
 
@@ -110,7 +110,7 @@ fun LoginScreen(
                             modifier =
                                 Modifier
                                     .size(112.dp)
-                                    .clip(RoundedCornerShape(24.dp)),
+                                    .clip(TuneFlowShapes.artwork),
                         )
                         Text(
                             text = "TuneFlow",
@@ -125,12 +125,12 @@ fun LoginScreen(
                         modifier =
                             Modifier
                                 .width(452.dp)
-                                .clip(RoundedCornerShape(24.dp))
+                                .clip(TuneFlowShapes.panel)
                                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.84f))
                                 .border(
                                     width = 1.dp,
                                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.20f),
-                                    shape = RoundedCornerShape(24.dp),
+                                    shape = TuneFlowShapes.panel,
                                 )
                                 .padding(22.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -313,6 +313,7 @@ private fun EditingLoginField(
         textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         visualTransformation = visualTransformation,
+        shape = TuneFlowShapes.field,
         modifier =
             Modifier
                 .fillMaxWidth()
@@ -363,7 +364,7 @@ private fun DisplayLoginField(
                 .fillMaxWidth()
                 .focusRequester(focusRequester)
                 .scale(if (focused) 1.01f else 1f)
-                .clip(RoundedCornerShape(18.dp))
+                .clip(TuneFlowShapes.field)
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f))
                 .border(
                     width = if (focused) 2.dp else 1.dp,
@@ -373,7 +374,7 @@ private fun DisplayLoginField(
                         } else {
                             MaterialTheme.colorScheme.outline
                         },
-                    shape = RoundedCornerShape(18.dp),
+                    shape = TuneFlowShapes.field,
                 )
                 .onFocusChanged { onFocusedChange(it.hasFocus) }
                 .focusable()
@@ -462,7 +463,7 @@ private fun LoginActionButton(
             Modifier
                 .fillMaxWidth()
                 .scale(scale)
-                .clip(RoundedCornerShape(18.dp))
+                .clip(TuneFlowShapes.button)
                 .background(
                     if (enabled) {
                         MaterialTheme.colorScheme.primary
@@ -480,7 +481,7 @@ private fun LoginActionButton(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
                         },
-                    shape = RoundedCornerShape(18.dp),
+                    shape = TuneFlowShapes.button,
                 )
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable(enabled = enabled)

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseFocusCard.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseFocusCard.kt
@@ -16,12 +16,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import com.tuneflow.core.design.TuneFlowShapes
 
 @Composable
 internal fun FocusScaleCard(
     modifier: Modifier = Modifier,
+    shape: Shape = TuneFlowShapes.card,
     onClick: () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -30,7 +32,7 @@ internal fun FocusScaleCard(
         modifier =
             modifier
                 .scale(if (focused) 1.01f else 1f)
-                .clip(TuneFlowShapes.card)
+                .clip(shape)
                 .background(
                     if (focused) {
                         MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
@@ -46,7 +48,7 @@ internal fun FocusScaleCard(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
                         },
-                    shape = TuneFlowShapes.card,
+                    shape = shape,
                 )
                 .onFocusChanged { focused = it.hasFocus }
                 .focusable()

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
@@ -230,7 +230,7 @@ fun AlbumDetailScreen(
                         Modifier
                             .width(292.dp)
                             .fillMaxSize()
-                            .clip(TuneFlowShapes.hero)
+                            .clip(TuneFlowShapes.container)
                             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f))
                             .padding(16.dp),
                 ) {
@@ -243,7 +243,7 @@ fun AlbumDetailScreen(
                             Modifier
                                 .fillMaxWidth()
                                 .height(248.dp)
-                                .clip(TuneFlowShapes.card)
+                                .clip(TuneFlowShapes.artwork)
                                 .align(Alignment.TopCenter),
                         contentScale = ContentScale.Crop,
                         placeholderText = album.title,
@@ -357,7 +357,7 @@ fun ArtistDetailScreen(
                         Modifier
                             .fillMaxWidth()
                             .height(208.dp)
-                            .clip(TuneFlowShapes.hero)
+                            .clip(TuneFlowShapes.container)
                             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f)),
                 ) {
                     TuneFlowArtwork(
@@ -563,7 +563,7 @@ fun PlaylistsScreen(
                     Modifier
                         .weight(1f)
                         .fillMaxSize()
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.panel)
                         .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f))
                         .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -627,7 +627,7 @@ fun PlaylistsScreen(
                     Modifier
                         .weight(1f)
                         .fillMaxSize()
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.panel)
                         .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f))
                         .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -1200,7 +1200,7 @@ private fun EmptyCategoryResults(message: String) {
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.panel)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f))
                 .padding(20.dp),
     ) {
@@ -1238,6 +1238,7 @@ private fun PremiumArtistRow(
 ) {
     FocusScaleCard(
         modifier = modifier.fillMaxWidth(),
+        shape = TuneFlowShapes.row,
         onClick = onClick,
     ) {
         Row(
@@ -1249,7 +1250,7 @@ private fun PremiumArtistRow(
                 modifier =
                     Modifier
                         .size(width = 92.dp, height = 68.dp)
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.66f)),
             ) {
                 TuneFlowArtwork(
@@ -1291,6 +1292,7 @@ private fun PremiumAlbumRow(
 ) {
     FocusScaleCard(
         modifier = modifier.fillMaxWidth(),
+        shape = TuneFlowShapes.row,
         onClick = onClick,
     ) {
         Row(
@@ -1302,7 +1304,7 @@ private fun PremiumAlbumRow(
                 modifier =
                     Modifier
                         .size(68.dp)
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.66f)),
             ) {
                 TuneFlowArtwork(
@@ -1346,6 +1348,7 @@ private fun PremiumPlaylistRow(
 ) {
     FocusScaleCard(
         modifier = modifier.fillMaxWidth(),
+        shape = TuneFlowShapes.row,
         onClick = onClick,
     ) {
         Row(
@@ -1359,7 +1362,7 @@ private fun PremiumPlaylistRow(
                 modifier =
                     Modifier
                         .size(58.dp)
-                        .clip(TuneFlowShapes.card),
+                        .clip(TuneFlowShapes.artwork),
             )
             Column(
                 modifier = Modifier.weight(1f),
@@ -1496,6 +1499,7 @@ private fun EditingSearchField(
         textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
         keyboardOptions = KeyboardOptions.Default,
         visualTransformation = VisualTransformation.None,
+        shape = TuneFlowShapes.field,
         modifier =
             Modifier
                 .fillMaxWidth()
@@ -1639,7 +1643,7 @@ private fun PremiumAlbumCard(
                     Modifier
                         .fillMaxWidth()
                         .height(196.dp)
-                        .clip(TuneFlowShapes.card)
+                        .clip(TuneFlowShapes.artwork)
                         .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.82f)),
             ) {
                 TuneFlowArtwork(
@@ -1681,6 +1685,7 @@ private fun PremiumListRow(
 ) {
     FocusScaleCard(
         modifier = modifier.fillMaxWidth(),
+        shape = TuneFlowShapes.row,
         onClick = onClick,
     ) {
         Row(
@@ -1741,6 +1746,7 @@ private fun PremiumChip(
 ) {
     FocusScaleCard(
         modifier = modifier.width(172.dp),
+        shape = TuneFlowShapes.badge,
         onClick = onClick,
     ) {
         Text(
@@ -1912,7 +1918,7 @@ private fun AlbumCardSkeleton() {
                 Modifier
                     .fillMaxWidth()
                     .height(196.dp)
-                    .clip(TuneFlowShapes.card)
+                    .clip(TuneFlowShapes.artwork)
                     .shimmerEffect(),
         )
         Box(
@@ -1943,7 +1949,7 @@ private fun DetailArtworkSkeleton(
     Box(
         modifier =
             modifier
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.container)
                 .shimmerEffect(),
     ) {
         Box(
@@ -1951,7 +1957,7 @@ private fun DetailArtworkSkeleton(
                 Modifier
                     .width(artworkWidth)
                     .height(artworkHeight)
-                    .clip(TuneFlowShapes.card)
+                    .clip(TuneFlowShapes.artwork)
                     .shimmerEffect()
                     .align(Alignment.TopCenter),
         )
@@ -1993,7 +1999,7 @@ private fun ListRowSkeleton() {
             Modifier
                 .fillMaxWidth()
                 .height(72.dp)
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.row)
                 .shimmerEffect(),
     )
 }
@@ -2005,7 +2011,7 @@ private fun ChipSkeleton() {
             Modifier
                 .width(172.dp)
                 .height(56.dp)
-                .clip(TuneFlowShapes.button)
+                .clip(TuneFlowShapes.badge)
                 .shimmerEffect(),
     )
 }
@@ -2021,7 +2027,7 @@ private fun AlbumDetailSkeleton(modifier: Modifier = Modifier) {
                 Modifier
                     .width(292.dp)
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f), TuneFlowShapes.hero)
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.66f), TuneFlowShapes.container)
                     .padding(16.dp),
             artworkWidth = 260.dp,
             artworkHeight = 248.dp,
@@ -2063,7 +2069,7 @@ private fun ArtistDetailSkeleton(modifier: Modifier = Modifier) {
                 Modifier
                     .fillMaxWidth()
                     .height(208.dp)
-                    .clip(TuneFlowShapes.hero)
+                    .clip(TuneFlowShapes.container)
                     .shimmerEffect(),
         )
         TextLineSkeleton(widthFraction = 0.28f, height = 34.dp)

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/LyricsRenderer.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/LyricsRenderer.kt
@@ -166,12 +166,12 @@ internal fun LyricsPanel(
             Modifier
                 .width(312.dp)
                 .fillMaxHeight()
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.panel)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.76f))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.16f),
-                    shape = TuneFlowShapes.card,
+                    shape = TuneFlowShapes.panel,
                 )
                 .onPreviewKeyEvent { event ->
                     if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -142,7 +141,7 @@ internal fun ArtworkCard(
             Modifier
                 .fillMaxWidth()
                 .height(artFrameHeight)
-                .clip(TuneFlowShapes.albumArt)
+                .clip(TuneFlowShapes.artwork)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.82f))
                 .animateContentSize()
                 .padding(10.dp),
@@ -152,7 +151,7 @@ internal fun ArtworkCard(
             modifier =
                 Modifier
                     .size(artSize)
-                    .clip(TuneFlowShapes.albumArt)
+                    .clip(TuneFlowShapes.artwork)
                     .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.78f)),
             contentAlignment = Alignment.Center,
         ) {
@@ -592,7 +591,7 @@ internal fun PlaybackIconButton(
                 .size(buttonSize)
                 .focusRequester(focusRequester)
                 .scale(scale)
-                .clip(CircleShape)
+                .clip(TuneFlowShapes.iconButton)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = if (focused) 0.22f else 0.08f))
                 .border(
                     width = if (focused) 3.dp else 1.dp,
@@ -602,7 +601,7 @@ internal fun PlaybackIconButton(
                         } else {
                             MaterialTheme.colorScheme.outline.copy(alpha = 0.24f)
                         },
-                    shape = CircleShape,
+                    shape = TuneFlowShapes.iconButton,
                 )
                 .onFocusChanged { focusState -> focused = focusState.hasFocus }
                 .focusable()

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -357,12 +357,12 @@ private fun QueuePanel(
             Modifier
                 .width(312.dp)
                 .fillMaxHeight()
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.panel)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.76f))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.16f),
-                    shape = TuneFlowShapes.card,
+                    shape = TuneFlowShapes.panel,
                 )
                 .onPreviewKeyEvent { event ->
                     if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
@@ -529,12 +529,12 @@ internal fun PlaybackStatusCard(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clip(TuneFlowShapes.card)
+                .clip(TuneFlowShapes.panel)
                 .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.48f))
                 .border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f),
-                    shape = TuneFlowShapes.card,
+                    shape = TuneFlowShapes.panel,
                 )
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),


### PR DESCRIPTION
## Summary

- Make `core/design` the single source of truth for semantic surface, container, card, button, row, field, panel, badge, artwork, and intentional circular shape tokens.
- Apply the approved 8dp rectangular radius across shell, Home, Login, browse, playback, lyrics, loading, empty, error, focus, and selected states.
- Preserve circular avatars and icon controls plus pill-shaped progress tracks as documented exceptions.
- Update Material theme shapes and `docs/design-system.md`, with focused token tests.

## Stack

- Depends on #111, which depends on #110.
- Base branch: `feat/issue-109-playback-screensaver`.

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`
- 536 tasks completed successfully.
- Static audit confirms no ad hoc `RoundedCornerShape` or `CircleShape` usage outside `TuneFlowShapes` and its tests.

## Device verification

Debug APK installation on the connected Fire TV was blocked by `INSTALL_FAILED_UPDATE_INCOMPATIBLE` because the installed `com.tuneflow.tv` uses a different signing key. Existing app and data were left untouched, so full device screenshot review remains pending.

Closes #107