### PR TITLE
ci: publish service images with TuneFlow releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 10
+    groups:
+      gradle-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gomod
+    directory: "/services/preferred-video"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:15"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 10
+    groups:
+      go-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: "/services/preferred-video"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 10
+    groups:
+      docker-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:45"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/preferred-video-service-ci.yml
+++ b/.github/workflows/preferred-video-service-ci.yml
@@ -5,11 +5,15 @@ on:
     branches: ["main"]
     paths:
       - "services/preferred-video/**"
+      - ".github/dependabot.yml"
+      - ".github/workflows/release.yml"
       - ".github/workflows/preferred-video-service-ci.yml"
       - ".github/workflows/preferred-video-service-publish.yml"
   pull_request:
     paths:
       - "services/preferred-video/**"
+      - ".github/dependabot.yml"
+      - ".github/workflows/release.yml"
       - ".github/workflows/preferred-video-service-ci.yml"
       - ".github/workflows/preferred-video-service-publish.yml"
 

--- a/.github/workflows/preferred-video-service-publish.yml
+++ b/.github/workflows/preferred-video-service-publish.yml
@@ -1,11 +1,9 @@
-name: Publish Preferred Video Service Image
+name: Publish Preferred Video Service Edge Image
 
 on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -43,8 +41,7 @@ jobs:
         with:
           images: ghcr.io/venkatpandey/tuneflow-preferred-video
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
+            type=raw,value=edge
             type=sha
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -72,6 +73,41 @@ jobs:
           else
             git log "$PREV_TAG"..HEAD --pretty=format:"- %s" > CHANGELOG.md
           fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract preferred-video image metadata
+        id: preferred-video-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/venkatpandey/tuneflow-preferred-video
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and publish preferred-video image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/preferred-video
+          file: services/preferred-video/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.preferred-video-meta.outputs.tags }}
+          labels: ${{ steps.preferred-video-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2

--- a/services/preferred-video/README.md
+++ b/services/preferred-video/README.md
@@ -46,7 +46,7 @@ docker compose pull
 docker compose up -d
 ```
 
-`latest` is published from `main`. Version tags such as `v1.2.0` publish an immutable matching image tag, and each build also publishes a `sha-...` tag. Set `PREFERRED_VIDEO_IMAGE_TAG` to a version or commit tag when a deployment must stay pinned.
+Each TuneFlow release publishes the preferred-video image with the same version tag, updates `latest`, and also publishes a `sha-...` tag. For example, release `v1.2.0` publishes both `v1.2.0` and `latest`. Builds from `main` publish `edge` and `sha-...`, but do not move the production `latest` tag. Set `PREFERRED_VIDEO_IMAGE_TAG` to a version or commit tag when a deployment must stay pinned.
 
 The GitHub Actions publish workflow builds both `linux/amd64` and `linux/arm64` images and pushes them to GHCR. After the first publish, make the package public in GitHub package settings for anonymous NAS pulls. If it remains private, log in on the NAS before pulling:
 


### PR DESCRIPTION
## Summary
- publish the multi-arch preferred-video image from the TuneFlow release workflow
- tag release images with the exact release tag and `latest`; publish main builds as `edge`
- enable weekly Dependabot updates for Gradle, Go, Docker, and GitHub Actions

## Verification
- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt --stacktrace`
- `go test -race ./...`
- `go vet ./...`
- `docker compose config --quiet`
- `docker build --tag tuneflow-preferred-video:test .`
- actionlint for all workflows
- YAML parse for workflows, Compose, and Dependabot config