### PR TITLE
ci: migrate workflows to Node 24 actions

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build Debug APK
         run: ./gradlew :app:assembleDebug --stacktrace
@@ -39,7 +39,7 @@ jobs:
         run: ./gradlew ktlintCheck detekt --stacktrace
 
       - name: Upload Debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tuneflow-tv-debug-apk
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/preferred-video-service-ci.yml
+++ b/.github/workflows/preferred-video-service-ci.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: services/preferred-video/go.mod
           cache-dependency-path: services/preferred-video/go.sum

--- a/.github/workflows/preferred-video-service-publish.yml
+++ b/.github/workflows/preferred-video-service-publish.yml
@@ -20,16 +20,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/venkatpandey/tuneflow-preferred-video
           tags: |
@@ -45,7 +45,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: services/preferred-video
           file: services/preferred-video/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Decode keystore
         env:
@@ -75,13 +75,13 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Extract preferred-video image metadata
         id: preferred-video-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/venkatpandey/tuneflow-preferred-video
           tags: |
@@ -98,7 +98,7 @@ jobs:
             type=sha
 
       - name: Build and publish preferred-video image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: services/preferred-video
           file: services/preferred-video/Dockerfile
@@ -110,7 +110,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             tuneflow-tv.apk


### PR DESCRIPTION
## Summary
- upgrade all workflow actions that still target Node.js 20
- update Android and Go CI actions too, preventing the same warning outside release jobs
- keep release, GHCR, caching, and artifact behavior unchanged

## Verification
- all selected action releases declare Node.js 24 or compose Node.js 24 actions
- actionlint passed for every workflow
- workflow YAML parsing passed
- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt --stacktrace`
- `go test -race ./...`
- `go vet ./...`
- `docker compose config --quiet`
- preferred-video Docker image build