### PR TITLE
feat(video): expand history and show track details

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
+++ b/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
@@ -64,6 +64,7 @@ import com.tuneflow.feature.playback.LyricsUiState
 import com.tuneflow.feature.video.NativeVideoPlayerSurface
 import com.tuneflow.feature.video.VideoUiState
 import com.tuneflow.feature.video.VideoViewModel
+import com.tuneflow.feature.video.activeTrackDetails
 import com.tuneflow.feature.video.hasVisiblePlayer
 import com.tuneflow.feature.video.isFullscreen
 import com.tuneflow.feature.video.isVideoSessionActive
@@ -284,6 +285,7 @@ internal fun TuneFlowShellLayout(
             )
             NativeVideoPlayerSurface(
                 player = videoSurfacePlayer,
+                trackDetails = requireNotNull(videoState.activeTrackDetails),
                 host = videoOverlayHost,
                 bounds = playerBounds,
                 requestFocus = videoState.isFullscreen,

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoComposables.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoComposables.kt
@@ -65,6 +65,7 @@ import java.text.NumberFormat
 @Composable
 fun NativeVideoPlayerSurface(
     player: NativeVideoPlayer,
+    trackDetails: VideoTrackDetails,
     host: FrameLayout,
     bounds: IntRect,
     requestFocus: Boolean,
@@ -78,7 +79,7 @@ fun NativeVideoPlayerSurface(
     val typography = MaterialTheme.typography
     val shapes = MaterialTheme.shapes
     val controlsView =
-        remember(player, host, requestFocus, colorScheme, typography, shapes) {
+        remember(player, trackDetails, host, requestFocus, colorScheme, typography, shapes) {
             if (requestFocus) {
                 ComposeView(host.context).apply {
                     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
@@ -88,7 +89,13 @@ fun NativeVideoPlayerSurface(
                             typography = typography,
                             shapes = shapes,
                         ) {
-                            NativeVideoControlsOverlay(player, onExitFullscreen, onChooseAnother, onStop)
+                            NativeVideoControlsOverlay(
+                                player = player,
+                                trackDetails = trackDetails,
+                                onExitFullscreen = onExitFullscreen,
+                                onChooseAnother = onChooseAnother,
+                                onStop = onStop,
+                            )
                         }
                     }
                 }
@@ -179,6 +186,7 @@ fun NativeVideoPlayerSurface(
 @Suppress("CyclomaticComplexMethod")
 private fun NativeVideoControlsOverlay(
     player: NativeVideoPlayer,
+    trackDetails: VideoTrackDetails,
     onExitFullscreen: () -> Unit,
     onChooseAnother: () -> Unit,
     onStop: () -> Unit,
@@ -289,6 +297,7 @@ private fun NativeVideoControlsOverlay(
                         .padding(horizontal = 34.dp, vertical = 22.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                VideoTrackDetailsBlock(trackDetails)
                 LinearProgressIndicator(
                     progress = { if (durationMs > 0L) positionMs.toFloat() / durationMs else 0f },
                     modifier = Modifier.fillMaxWidth().height(6.dp).progressSemantics(),
@@ -445,6 +454,30 @@ private fun NativeVideoControlsOverlay(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun VideoTrackDetailsBlock(trackDetails: VideoTrackDetails) {
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Text(
+            text = trackDetails.title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text =
+                listOf(trackDetails.artist, trackDetails.album)
+                    .filter(String::isNotBlank)
+                    .joinToString(" • "),
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White.copy(alpha = 0.78f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoHistoryStore.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoHistoryStore.kt
@@ -291,7 +291,7 @@ private data class PreferredVideoWrite(
     val viewCount: Long,
 )
 
-const val VIDEO_HISTORY_LIMIT = 20
+const val VIDEO_HISTORY_LIMIT = 100
 internal const val YOUTUBE_PROVIDER = "youtube"
 private const val API_VERSION = "v1"
 private const val MAX_RESPONSE_CHARACTERS = 256 * 1024

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoModels.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoModels.kt
@@ -16,6 +16,12 @@ data class VideoTrackQuery(
     val languageCode: String?,
 )
 
+data class VideoTrackDetails(
+    val title: String,
+    val artist: String,
+    val album: String,
+)
+
 data class VideoCandidate(
     val videoId: String,
     val title: String,
@@ -191,6 +197,7 @@ sealed interface VideoUiState {
         override val trackId: String,
         val generation: Long,
         val candidate: VideoCandidate,
+        val trackDetails: VideoTrackDetails,
         val presentation: VideoPresentationMode,
         val focusRequestId: Long = 0L,
     ) : VideoUiState
@@ -199,6 +206,7 @@ sealed interface VideoUiState {
         override val trackId: String,
         val generation: Long,
         val candidate: VideoCandidate,
+        val trackDetails: VideoTrackDetails,
         val presentation: VideoPresentationMode,
         val positionMs: Long,
         val durationMs: Long,
@@ -227,6 +235,14 @@ val VideoUiState.isFullscreen: Boolean
 val VideoUiState.isVideoSessionActive: Boolean
     get() = this is VideoUiState.Loading || this is VideoUiState.Playing
 
+val VideoUiState.activeTrackDetails: VideoTrackDetails?
+    get() =
+        when (this) {
+            is VideoUiState.Loading -> trackDetails
+            is VideoUiState.Playing -> trackDetails
+            else -> null
+        }
+
 fun QueueItem.toVideoTrackQuery(
     regionCode: String?,
     languageCode: String?,
@@ -239,4 +255,11 @@ fun QueueItem.toVideoTrackQuery(
         durationMs = durationMs,
         regionCode = regionCode,
         languageCode = languageCode,
+    )
+
+fun QueueItem.toVideoTrackDetails(): VideoTrackDetails =
+    VideoTrackDetails(
+        title = title,
+        artist = artist,
+        album = album,
     )

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoViewModel.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoViewModel.kt
@@ -163,11 +163,21 @@ class VideoViewModel(
         recordedVideoIdForSession = null
         playbackPersistenceAction = persistenceAction
         val session = VideoSessionKey(trackId, generation)
+        val trackDetails =
+            audio.queue.value.items
+                .firstOrNull { it.id == trackId }
+                ?.toVideoTrackDetails()
+                ?: VideoTrackDetails(
+                    title = candidate.title,
+                    artist = candidate.publisher,
+                    album = "",
+                )
         _uiState.value =
             VideoUiState.Loading(
                 trackId = trackId,
                 generation = generation,
                 candidate = candidate,
+                trackDetails = trackDetails,
                 presentation = VideoPresentationMode.Fullscreen,
             )
         nativeBackend.player.prepare(session, NativeVideoSpec(candidate.videoId))
@@ -430,11 +440,13 @@ class VideoViewModel(
                 is VideoUiState.Playing -> current.focusRequestId
                 else -> 0L
             }
+        val trackDetails = current.activeTrackDetails ?: return
         _uiState.value =
             VideoUiState.Playing(
                 trackId = session.trackId,
                 generation = session.generation,
                 candidate = candidate,
+                trackDetails = trackDetails,
                 presentation = presentation,
                 positionMs = state.positionMsOrZero(),
                 durationMs = state.durationMsOrZero().takeIf { it > 0L } ?: candidate.durationMs,

--- a/feature/video/src/test/java/com/tuneflow/feature/video/VideoHistoryStoreTest.kt
+++ b/feature/video/src/test/java/com/tuneflow/feature/video/VideoHistoryStoreTest.kt
@@ -28,6 +28,22 @@ class VideoHistoryStoreTest {
         }
 
     @Test
+    fun historyRequestsUpToOneHundredVideos() =
+        runTest {
+            MockWebServer().use { server ->
+                server.enqueue(
+                    MockResponse()
+                        .setResponseCode(200)
+                        .setBody("""{"apiVersion":"v1","videos":[]}"""),
+                )
+                val store = RemotePreferredVideoStore(server.url("/").toString())
+
+                assertTrue(store.refreshHistory())
+                assertEquals("/v1/videos/recent?limit=100", server.takeRequest().path)
+            }
+        }
+
+    @Test
     fun repeatedTrackMovesToFrontWithoutDuplication() {
         val first = historyEntry("track-1", "aaaaaaaaaaa", "2026-09-01T10:00:00Z")
         val second = historyEntry("track-2", "bbbbbbbbbbb", "2026-09-01T11:00:00Z")
@@ -39,7 +55,7 @@ class VideoHistoryStoreTest {
     }
 
     @Test
-    fun inMemoryHistoryKeepsOnlyTwentyNewestMappings() {
+    fun inMemoryHistoryKeepsOnlyOneHundredNewestMappings() {
         val existing =
             (0 until VIDEO_HISTORY_LIMIT).map {
                 historyEntry("track-$it", "video${it.toString().padStart(6, '0')}", "2026-09-01T10:00:00Z")
@@ -51,9 +67,9 @@ class VideoHistoryStoreTest {
                 historyEntry("new", "newvideo001", "2026-09-01T12:00:00Z"),
             )
 
-        assertEquals(VIDEO_HISTORY_LIMIT, updated.size)
+        assertEquals(100, updated.size)
         assertEquals("new", updated.first().trackId)
-        assertEquals("track-18", updated.last().trackId)
+        assertEquals("track-98", updated.last().trackId)
     }
 
     @Test

--- a/feature/video/src/test/java/com/tuneflow/feature/video/VideoViewModelTest.kt
+++ b/feature/video/src/test/java/com/tuneflow/feature/video/VideoViewModelTest.kt
@@ -210,6 +210,10 @@ class VideoViewModelTest {
 
             val loading = viewModel.uiState.value as VideoUiState.Loading
             assertEquals(VideoPresentationMode.Fullscreen, loading.presentation)
+            assertEquals(
+                VideoTrackDetails(title = "Track", artist = "Artist", album = "Album"),
+                loading.trackDetails,
+            )
 
             viewModel.exitFullscreen()
 

--- a/services/preferred-video/README.md
+++ b/services/preferred-video/README.md
@@ -101,7 +101,7 @@ All JSON responses include `"apiVersion":"v1"`.
 - `PUT /v1/tracks/{trackId}/preferred-video`
 - `DELETE /v1/tracks/{trackId}/preferred-video`
 - `POST /v1/tracks/{trackId}/preferred-video/played`
-- `GET /v1/videos/recent?limit=5` (`limit` capped at 20)
+- `GET /v1/videos/recent?limit=5` (`limit` capped at 100)
 
 Example mapping write after confirmed playback:
 

--- a/services/preferred-video/internal/api/handler.go
+++ b/services/preferred-video/internal/api/handler.go
@@ -21,7 +21,7 @@ import (
 const (
 	apiVersion      = "v1"
 	defaultLimit    = 5
-	maximumLimit    = 20
+	maximumLimit    = 100
 	maximumBodySize = 64 * 1024
 )
 

--- a/services/preferred-video/internal/api/handler_test.go
+++ b/services/preferred-video/internal/api/handler_test.go
@@ -79,15 +79,15 @@ func TestDatabaseFailureReturnsGenericServerError(t *testing.T) {
 	}
 }
 
-func TestRecentLimitIsCappedAtTwenty(t *testing.T) {
+func TestRecentLimitIsCappedAtOneHundred(t *testing.T) {
 	store := &fakeStore{recentVideos: []model.PreferredVideo{}}
 	response := serve(t, store, http.MethodGet, "/v1/videos/recent?limit=200", "")
 
 	if response.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
 	}
-	if store.recentLimit != maximumLimit {
-		t.Fatalf("recent limit = %d, want %d", store.recentLimit, maximumLimit)
+	if store.recentLimit != 100 {
+		t.Fatalf("recent limit = %d, want 100", store.recentLimit)
 	}
 }
 


### PR DESCRIPTION
## Summary

- increase recent video history from 20 to 100 entries in the Android client and preferred-video service
- show the track title prominently above the fullscreen video progress bar
- show artist and album as secondary metadata and preserve those details through loading and playback states
- add regression coverage for the 100-entry request/caps and track metadata propagation

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`
- `go test ./...` in `services/preferred-video`