### PR TITLE
feat(playback): show playlist context in now playing

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -343,7 +343,11 @@ private suspend fun cyclePlaybackStreamMode(
             )
         }
 
-    playerManager.playQueue(updatedItems, queue.currentIndex)
+    playerManager.playQueue(
+        items = updatedItems,
+        startIndex = queue.currentIndex,
+        sourcePlaylistName = queue.sourcePlaylistName,
+    )
     playerManager.seekTo(positionMs)
     if (!wasPlaying) {
         playerManager.pause()
@@ -501,21 +505,18 @@ private fun TuneFlowShell(
     fun playTracks(
         tracks: List<com.tuneflow.core.network.TrackSummary>,
         index: Int,
+        sourcePlaylistName: String? = null,
     ) {
         scope.launch {
             val queue = buildQueueItems(tracks, browseRepository, preferDirectWithFallback)
-            playerManager.playQueue(queue, index)
+            playerManager.playQueue(queue, index, sourcePlaylistName)
         }
     }
 
-    fun shuffleTracks(tracks: List<com.tuneflow.core.network.TrackSummary>) {
-        scope.launch {
-            if (tracks.isEmpty()) return@launch
-            val shuffledTracks = tracks.shuffled()
-            val queue = buildQueueItems(shuffledTracks, browseRepository, preferDirectWithFallback)
-            playerManager.playQueue(queue, 0)
-        }
-    }
+    fun shuffleTracks(
+        tracks: List<com.tuneflow.core.network.TrackSummary>,
+        sourcePlaylistName: String? = null,
+    ) = playTracks(tracks.shuffled(), index = 0, sourcePlaylistName)
 
     fun cycleStreamMode() {
         scope.launch {
@@ -615,8 +616,14 @@ private fun TuneFlowShell(
             videoViewModel.playHistory(entry)
             navigationActions.openNowPlaying()
         },
-        onPlayTracks = ::playTracks,
-        onShuffleTracks = ::shuffleTracks,
+        onPlayTracks = { tracks, index -> playTracks(tracks, index) },
+        onShuffleTracks = { tracks -> shuffleTracks(tracks) },
+        onPlayPlaylistTracks = { playlistName, tracks, index ->
+            playTracks(tracks, index, playlistName)
+        },
+        onShufflePlaylistTracks = { playlistName, tracks ->
+            shuffleTracks(tracks, playlistName)
+        },
         preferredVideoServiceUrl = preferredVideoServiceUrl,
         onPreferredVideoServiceUrlChanged = { serviceUrl ->
             onPreferredVideoServiceUrlChanged(serviceUrl)

--- a/app/src/main/java/com/tuneflow/tv/TuneFlowShellContent.kt
+++ b/app/src/main/java/com/tuneflow/tv/TuneFlowShellContent.kt
@@ -45,6 +45,8 @@ internal fun ShellContent(
     onPlayVideo: (com.tuneflow.feature.video.VideoHistoryEntry) -> Unit,
     onPlayTracks: (List<com.tuneflow.core.network.TrackSummary>, Int) -> Unit,
     onShuffleTracks: (List<com.tuneflow.core.network.TrackSummary>) -> Unit,
+    onPlayPlaylistTracks: (String, List<com.tuneflow.core.network.TrackSummary>, Int) -> Unit,
+    onShufflePlaylistTracks: (String, List<com.tuneflow.core.network.TrackSummary>) -> Unit,
     preferredVideoServiceUrl: String,
     onPreferredVideoServiceUrlChanged: (String) -> Unit,
 ) {
@@ -131,8 +133,8 @@ internal fun ShellContent(
                     preselectedPlaylistId = preselectedPlaylistId,
                     onPreselectedPlaylistConsumed = onPreselectedPlaylistConsumed,
                     currentTrackId = playbackQueue.currentItem?.id,
-                    onPlayTracks = onPlayTracks,
-                    onShuffleTracks = onShuffleTracks,
+                    onPlayTracks = onPlayPlaylistTracks,
+                    onShuffleTracks = onShufflePlaylistTracks,
                 )
             }
             ShellDestination.Search -> {

--- a/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
+++ b/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
@@ -115,6 +115,8 @@ internal fun TuneFlowShellLayout(
     onPlayVideo: (com.tuneflow.feature.video.VideoHistoryEntry) -> Unit,
     onPlayTracks: (List<com.tuneflow.core.network.TrackSummary>, Int) -> Unit,
     onShuffleTracks: (List<com.tuneflow.core.network.TrackSummary>) -> Unit,
+    onPlayPlaylistTracks: (String, List<com.tuneflow.core.network.TrackSummary>, Int) -> Unit,
+    onShufflePlaylistTracks: (String, List<com.tuneflow.core.network.TrackSummary>) -> Unit,
     preferredVideoServiceUrl: String,
     onPreferredVideoServiceUrlChanged: (String) -> Unit,
     showExitPrompt: Boolean,
@@ -236,6 +238,8 @@ internal fun TuneFlowShellLayout(
                                 onPlayVideo = onPlayVideo,
                                 onPlayTracks = onPlayTracks,
                                 onShuffleTracks = onShuffleTracks,
+                                onPlayPlaylistTracks = onPlayPlaylistTracks,
+                                onShufflePlaylistTracks = onShufflePlaylistTracks,
                                 preferredVideoServiceUrl = preferredVideoServiceUrl,
                                 onPreferredVideoServiceUrlChanged = onPreferredVideoServiceUrlChanged,
                             )

--- a/core/player/src/main/java/com/tuneflow/core/player/PlaybackQueue.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/PlaybackQueue.kt
@@ -27,6 +27,7 @@ data class PlaybackQueue(
     val items: List<QueueItem> = emptyList(),
     val currentIndex: Int = 0,
     val currentPositionMs: Long = 0L,
+    val sourcePlaylistName: String? = null,
 ) {
     val currentItem: QueueItem?
         get() = items.getOrNull(currentIndex)
@@ -34,10 +35,16 @@ data class PlaybackQueue(
     fun replace(
         items: List<QueueItem>,
         startIndex: Int = 0,
+        sourcePlaylistName: String? = null,
     ): PlaybackQueue {
         if (items.isEmpty()) return PlaybackQueue()
         val clamped = startIndex.coerceIn(0, items.lastIndex)
-        return copy(items = items, currentIndex = clamped, currentPositionMs = 0L)
+        return copy(
+            items = items,
+            currentIndex = clamped,
+            currentPositionMs = 0L,
+            sourcePlaylistName = sourcePlaylistName?.trim()?.takeIf(String::isNotEmpty),
+        )
     }
 
     fun next(positionMs: Long = 0L): PlaybackQueue {

--- a/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
@@ -172,10 +172,11 @@ class TvPlayerManager(
     fun playQueue(
         items: List<QueueItem>,
         startIndex: Int = 0,
+        sourcePlaylistName: String? = null,
     ) {
         if (items.isEmpty()) return
 
-        val queue = PlaybackQueue().replace(items, startIndex)
+        val queue = PlaybackQueue().replace(items, startIndex, sourcePlaylistName)
         _queue.value = queue
         lastError = null
         expectedToPlay = true

--- a/core/player/src/test/java/com/tuneflow/core/player/PlaybackQueueTest.kt
+++ b/core/player/src/test/java/com/tuneflow/core/player/PlaybackQueueTest.kt
@@ -20,6 +20,15 @@ class PlaybackQueueTest {
     }
 
     @Test
+    fun replace_keepsPlaylistNameAcrossQueueNavigation() {
+        val queue = PlaybackQueue().replace(items, sourcePlaylistName = "Evening Mix")
+
+        assertEquals("Evening Mix", queue.sourcePlaylistName)
+        assertEquals("Evening Mix", queue.next().sourcePlaylistName)
+        assertEquals("Evening Mix", queue.next().previous().sourcePlaylistName)
+    }
+
+    @Test
     fun next_stopsAtLastItem() {
         val queue = PlaybackQueue(items, currentIndex = 2)
         val next = queue.next()
@@ -35,8 +44,14 @@ class PlaybackQueueTest {
 
     @Test
     fun replace_emptyClearsQueue() {
-        val queue = PlaybackQueue(items, currentIndex = 1).replace(emptyList())
+        val queue =
+            PlaybackQueue(
+                items = items,
+                currentIndex = 1,
+                sourcePlaylistName = "Evening Mix",
+            ).replace(emptyList())
         assertNull(queue.currentItem)
         assertEquals(0, queue.currentIndex)
+        assertNull(queue.sourcePlaylistName)
     }
 }

--- a/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
+++ b/feature/browse/src/main/java/com/tuneflow/feature/browse/BrowseScreens.kt
@@ -418,8 +418,8 @@ fun PlaylistsScreen(
     preselectedPlaylistId: String? = null,
     onPreselectedPlaylistConsumed: () -> Unit = {},
     currentTrackId: String? = null,
-    onPlayTracks: (tracks: List<TrackSummary>, index: Int) -> Unit,
-    onShuffleTracks: (tracks: List<TrackSummary>) -> Unit,
+    onPlayTracks: (playlistName: String, tracks: List<TrackSummary>, index: Int) -> Unit,
+    onShuffleTracks: (playlistName: String, tracks: List<TrackSummary>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -577,12 +577,12 @@ fun PlaylistsScreen(
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     BrowseActionButton(
-                        onClick = { onPlayTracks(selected.tracks, 0) },
+                        onClick = { onPlayTracks(selected.name, selected.tracks, 0) },
                         modifier = Modifier.focusRequester(playPlaylistFocusRequester),
                     ) {
                         BrowsePlayIcon()
                     }
-                    BrowseActionButton(onClick = { onShuffleTracks(selected.tracks) }) {
+                    BrowseActionButton(onClick = { onShuffleTracks(selected.name, selected.tracks) }) {
                         BrowseShuffleIcon()
                     }
                 }
@@ -602,6 +602,7 @@ fun PlaylistsScreen(
                             },
                             onClick = {
                                 onPlayTracks(
+                                    selected.name,
                                     selected.tracks,
                                     index,
                                 )

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
@@ -92,6 +92,7 @@ private fun VideoMiniViewport(onBoundsChanged: (IntRect) -> Unit) {
 internal fun NowPlayingPrimaryColumn(
     item: QueueItem?,
     state: NowPlayingUiState,
+    playlistName: String?,
     videoState: VideoUiState,
     artSize: Dp,
     artFrameHeight: Dp,
@@ -139,7 +140,7 @@ internal fun NowPlayingPrimaryColumn(
                 artFrameHeight = artFrameHeight,
             )
         }
-        TrackMetadata(item = item)
+        TrackMetadata(item = item, playlistName = playlistName)
         StreamControlRow(
             streamModeLabel = streamModeLabel,
             bitrateLabel = item?.streamBitrateLabel ?: "--",
@@ -248,7 +249,10 @@ internal fun ArtworkCard(
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
-internal fun TrackMetadata(item: QueueItem?) {
+internal fun TrackMetadata(
+    item: QueueItem?,
+    playlistName: String?,
+) {
     Text(
         text = item?.title ?: "Nothing playing",
         style = MaterialTheme.typography.headlineLarge,
@@ -271,7 +275,22 @@ internal fun TrackMetadata(item: QueueItem?) {
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
     )
+    playlistContextLabel(playlistName)?.let { label ->
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
+
+internal fun playlistContextLabel(playlistName: String?): String? =
+    playlistName
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?.let { "Playlist • $it" }
 
 @Composable
 internal fun StreamBadge(label: String) {

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -192,6 +192,7 @@ fun NowPlayingScreen(
                         .fillMaxHeight(),
                 item = item,
                 state = state,
+                playlistName = state.queue.sourcePlaylistName,
                 videoState = videoState,
                 artSize = artSize,
                 artFrameHeight = artFrameHeight,
@@ -262,6 +263,7 @@ fun NowPlayingScreen(
                     NowPlayingPanel.TrackList ->
                         QueuePanel(
                             title = "Track List",
+                            playlistName = state.queue.sourcePlaylistName,
                             state = state,
                             onSelectTrack = viewModel::playFromIndex,
                             onQueueExit = ::closeQueue,
@@ -443,6 +445,7 @@ internal fun resolveNowPlayingEscapeAction(
 @Composable
 private fun QueuePanel(
     title: String,
+    playlistName: String?,
     state: NowPlayingUiState,
     onSelectTrack: (Int) -> Unit,
     onQueueExit: (QueueExitTarget) -> Unit,
@@ -495,6 +498,15 @@ private fun QueuePanel(
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.onSurface,
         )
+        playlistName?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
         LazyColumn(
             state = queueListState,
             verticalArrangement = Arrangement.spacedBy(10.dp),

--- a/feature/playback/src/test/java/com/tuneflow/feature/playback/NowPlayingNavigationTest.kt
+++ b/feature/playback/src/test/java/com/tuneflow/feature/playback/NowPlayingNavigationTest.kt
@@ -66,4 +66,11 @@ class NowPlayingNavigationTest {
         assertEquals(QueueExitTarget.StreamControls, resolveQueueExitTarget(focusedIndex = 1, itemCount = 6))
         assertEquals(QueueExitTarget.TransportControls, resolveQueueExitTarget(focusedIndex = 5, itemCount = 6))
     }
+
+    @Test
+    fun playlistContextLabel_onlyShowsNamedPlaylist() {
+        assertEquals("Playlist • Evening Mix", playlistContextLabel(" Evening Mix "))
+        assertEquals(null, playlistContextLabel("  "))
+        assertEquals(null, playlistContextLabel(null))
+    }
 }


### PR DESCRIPTION
## Summary

- retain the source playlist name when playback starts from a playlist
- show the playlist beneath the track metadata on the Now Playing screen
- show the playlist name beneath the Track List heading
- preserve playlist context across queue navigation, restore, shuffle, and playback stream-mode changes
- hide playlist context for tracks started outside a playlist

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`