### PR TITLE
Continue playlist playback with preferred videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ If you use the Downloader app on Fire TV / Android TV, enter code `1578499`.
 - Search with recent queries and live suggestions
 - Use play/pause/previous/next on the Now Playing screen
 - Browse up to 25 ranked YouTube matches for the current song, choose one, and play it full screen
-- Reopen the 5 most recent videos from Home or show the last 20
+- Reopen the 5 most recent videos from Home or show the last 100
 - Persist preferred track videos and recent playback through an optional LAN Go/SQLite service
+- Use **Video preferred** in Now Playing to continue a playlist with mapped videos and audio fallback
 - Press Back to keep the selected video playing inside the Now Playing rail widget while browsing TuneFlow
 - Logout to switch users on the same TV
 
@@ -100,7 +101,9 @@ Native search works without a Google API key.
 
 For durable preferred videos and recent history across app reinstall or TV replacement, deploy the LAN-only service, then enter its URL under **Home > Quick Actions > Video Service**. No APK rebuild is required. See [preferred-video service deployment](services/preferred-video/README.md). If the service is missing, disabled, or offline, the Video button immediately uses normal YouTube search and playback continues normally.
 
-Video search starts only after the user selects it and accepts the one-time disclosure. TuneFlow ranks matches using title, artist, duration, category, publisher, and view count. The native player defaults to the highest supported quality, preserves the video's aspect ratio, and exposes quality and caption controls. Stopping, finishing, or failing video leaves audio paused and returns control to audio. Playback pauses when TuneFlow leaves the foreground.
+Video search starts only after the user selects it and accepts the one-time disclosure. TuneFlow ranks matches using title, artist, duration, category, publisher, and view count. The native player defaults to the highest supported quality, preserves the video's aspect ratio, and exposes quality and caption controls.
+
+For playlist queues, the **Video preferred** toggle in Now Playing makes each track use its saved preferred video when one exists and fall back to audio otherwise. Selecting a video for the current playlist track enables this mode automatically. When a video finishes, TuneFlow advances the same queue; disabling the mode switches an active video back to the matching audio position. Explicitly stopping a video still leaves audio paused. Playback pauses when TuneFlow leaves the foreground.
 
 ## Streaming Quality
 

--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -454,9 +454,9 @@ private fun TuneFlowShell(
     val playbackState by playbackViewModel.uiState.collectAsStateWithLifecycle()
     val lyricsState by playbackViewModel.lyricsState.collectAsStateWithLifecycle()
     val videoState by videoViewModel.uiState.collectAsStateWithLifecycle()
-    DisposableEffect(videoViewModel, playbackViewModel, onVideoMediaKeyHandlerChanged) {
+    DisposableEffect(videoViewModel, onVideoMediaKeyHandlerChanged) {
         onVideoMediaKeyHandlerChanged { keyCode ->
-            handleVideoModeMediaKey(keyCode, videoViewModel, playbackViewModel)
+            handleVideoModeMediaKey(keyCode, videoViewModel)
         }
         onDispose { onVideoMediaKeyHandlerChanged(null) }
     }

--- a/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
+++ b/app/src/main/java/com/tuneflow/tv/TuneFlowShellLayout.kt
@@ -140,7 +140,6 @@ internal fun TuneFlowShellLayout(
                         handleVideoModeMediaKey(
                             event.nativeKeyEvent.keyCode,
                             videoViewModel,
-                            playbackViewModel,
                         )
                 }
                 .background(MaterialTheme.colorScheme.background),
@@ -294,7 +293,7 @@ internal fun TuneFlowShellLayout(
                 bounds = playerBounds,
                 requestFocus = videoState.isFullscreen,
                 onKeyEvent = { event ->
-                    handleVideoOverlayMediaKey(event, videoViewModel, playbackViewModel)
+                    handleVideoOverlayMediaKey(event, videoViewModel)
                 },
                 onExitFullscreen = videoViewModel::exitFullscreen,
                 onChooseAnother = videoViewModel::chooseAnother,
@@ -339,16 +338,14 @@ private const val YOUTUBE_PLAYER_ASPECT_HEIGHT = 9L
 private fun handleVideoOverlayMediaKey(
     event: AndroidKeyEvent,
     videoViewModel: VideoViewModel,
-    playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel,
 ): Boolean {
     if (event.action != AndroidKeyEvent.ACTION_DOWN || isYouTubeProviderKey(event.keyCode)) return false
-    return handleVideoModeMediaKey(event.keyCode, videoViewModel, playbackViewModel)
+    return handleVideoModeMediaKey(event.keyCode, videoViewModel)
 }
 
 internal fun handleVideoModeMediaKey(
     keyCode: Int,
     videoViewModel: VideoViewModel,
-    playbackViewModel: com.tuneflow.feature.playback.PlaybackViewModel,
 ): Boolean {
     if (!videoViewModel.uiState.value.isVideoSessionActive) return false
     return when (keyCode) {
@@ -364,14 +361,10 @@ internal fun handleVideoModeMediaKey(
         AndroidKeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> videoViewModel.seekBy(10_000L)
         AndroidKeyEvent.KEYCODE_MEDIA_REWIND -> videoViewModel.seekBy(-10_000L)
         AndroidKeyEvent.KEYCODE_MEDIA_NEXT -> {
-            videoViewModel.closeForQueueChange()
-            playbackViewModel.next()
-            true
+            videoViewModel.nextTrack()
         }
         AndroidKeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
-            videoViewModel.closeForQueueChange()
-            playbackViewModel.previous()
-            true
+            videoViewModel.previousTrack()
         }
         else -> false
     }

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingComponents.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusRequester
@@ -37,6 +40,11 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntRect
@@ -99,10 +107,13 @@ internal fun NowPlayingPrimaryColumn(
     streamModeLabel: String,
     activePanel: NowPlayingPanel,
     hasLyrics: Boolean,
+    videoPreferred: Boolean,
+    videoPreferenceEnabled: Boolean,
     onCycleStreamMode: () -> Unit,
     onToggleQueue: () -> Unit,
     onToggleLyrics: () -> Unit,
     onVideoAction: () -> Unit,
+    onToggleVideoPreference: () -> Unit,
     onEnterFullscreen: () -> Unit,
     onStopVideo: () -> Unit,
     onVideoViewportBoundsChanged: (IntRect?) -> Unit,
@@ -146,6 +157,8 @@ internal fun NowPlayingPrimaryColumn(
             bitrateLabel = item?.streamBitrateLabel ?: "--",
             activePanel = activePanel,
             hasLyrics = hasLyrics,
+            videoPreferred = videoPreferred,
+            videoPreferenceEnabled = videoPreferenceEnabled,
             videoState = videoState,
             videoEnabled = item != null,
             onCycleStreamMode = onCycleStreamMode,
@@ -154,6 +167,7 @@ internal fun NowPlayingPrimaryColumn(
             onToggleQueue = onToggleQueue,
             onToggleLyrics = onToggleLyrics,
             onVideoAction = onVideoAction,
+            onToggleVideoPreference = onToggleVideoPreference,
             playbackMode = state.playbackMode,
             onCyclePlaybackMode = onCyclePlaybackMode,
             autoFocusQueue = autoFocusQueue,
@@ -359,6 +373,8 @@ internal fun StreamControlRow(
     hasLyrics: Boolean,
     videoState: VideoUiState,
     videoEnabled: Boolean,
+    videoPreferred: Boolean,
+    videoPreferenceEnabled: Boolean,
     playbackMode: PlaybackMode,
     onCycleStreamMode: () -> Unit,
     autoFocusStreamMode: Boolean,
@@ -366,6 +382,7 @@ internal fun StreamControlRow(
     onToggleQueue: () -> Unit,
     onToggleLyrics: () -> Unit,
     onVideoAction: () -> Unit,
+    onToggleVideoPreference: () -> Unit,
     onCyclePlaybackMode: () -> Unit,
     autoFocusQueue: Boolean,
     autoFocusLyrics: Boolean,
@@ -400,6 +417,11 @@ internal fun StreamControlRow(
                 onRequestedFocusApplied = onLyricsFocusConsumed,
             )
         }
+        VideoPreferenceToggleButton(
+            checked = videoPreferred,
+            enabled = videoPreferenceEnabled,
+            onClick = onToggleVideoPreference,
+        )
         VideoActionButton(
             state = videoState,
             enabled =
@@ -411,6 +433,68 @@ internal fun StreamControlRow(
             requestFocus = autoFocusVideo,
             onRequestedFocusApplied = onVideoFocusConsumed,
             onClick = onVideoAction,
+        )
+    }
+}
+
+@Composable
+private fun VideoPreferenceToggleButton(
+    checked: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    var focused by remember { mutableStateOf(false) }
+    Row(
+        modifier =
+            Modifier
+                .width(82.dp)
+                .height(44.dp)
+                .scale(if (focused) 1.04f else 1f)
+                .alpha(if (enabled) 1f else 0.45f)
+                .onFocusChanged { focused = it.hasFocus }
+                .focusable(enabled)
+                .clip(TuneFlowShapes.button)
+                .background(
+                    if (focused || checked) {
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.34f)
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.22f)
+                    },
+                )
+                .border(
+                    width = if (focused) 2.dp else 1.dp,
+                    color =
+                        if (focused) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
+                        },
+                    shape = TuneFlowShapes.button,
+                )
+                .semantics(mergeDescendants = true) {
+                    contentDescription = "Prefer videos in playlist"
+                    stateDescription = if (checked) "On" else "Off"
+                }
+                .toggleable(
+                    value = checked,
+                    enabled = enabled,
+                    role = Role.Switch,
+                    onValueChange = { onClick() },
+                )
+                .padding(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(VideoR.drawable.smarttube_ic_video),
+            contentDescription = null,
+            modifier = Modifier.size(22.dp),
+            tint = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = if (checked) "ON" else "OFF",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface,
         )
     }
 }

--- a/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
+++ b/feature/playback/src/main/java/com/tuneflow/feature/playback/NowPlayingScreen.kt
@@ -80,6 +80,7 @@ fun NowPlayingScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val lyricsState by viewModel.lyricsState.collectAsStateWithLifecycle()
     val videoState by videoViewModel.uiState.collectAsStateWithLifecycle()
+    val videoPreferred by videoViewModel.videoPreferred.collectAsStateWithLifecycle()
     val item = state.queue.currentItem
     val availableLyrics =
         (lyricsState as? LyricsUiState.Available)
@@ -199,6 +200,8 @@ fun NowPlayingScreen(
                 streamModeLabel = streamModeLabel,
                 activePanel = activePanel,
                 hasLyrics = availableLyrics != null,
+                videoPreferred = videoPreferred,
+                videoPreferenceEnabled = !state.queue.sourcePlaylistName.isNullOrBlank(),
                 onCycleStreamMode = onCycleStreamMode,
                 onToggleQueue = {
                     activePanel = toggleNowPlayingPanel(activePanel, NowPlayingPanel.TrackList)
@@ -219,6 +222,7 @@ fun NowPlayingScreen(
                     }
                     clearRequestedFocus()
                 },
+                onToggleVideoPreference = videoViewModel::toggleVideoPreferredMode,
                 onEnterFullscreen = videoViewModel::enterFullscreen,
                 onStopVideo = videoViewModel::stopVideo,
                 onVideoViewportBoundsChanged = onVideoViewportBoundsChanged,
@@ -376,14 +380,10 @@ private fun handleNowPlayingKeyEvent(
                 true
             }
             AndroidKeyEvent.KEYCODE_MEDIA_NEXT -> {
-                videoViewModel.closeForQueueChange()
-                viewModel.next()
-                true
+                videoViewModel.nextTrack()
             }
             AndroidKeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
-                videoViewModel.closeForQueueChange()
-                viewModel.previous()
-                true
+                videoViewModel.previousTrack()
             }
             else -> false
         }

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoViewModel.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tuneflow.core.player.PlaybackController
+import com.tuneflow.core.player.PlaybackQueue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -33,20 +34,31 @@ class VideoViewModel(
     val uiState: kotlinx.coroutines.flow.StateFlow<VideoUiState> = _uiState
     private val _surfacePlayer = kotlinx.coroutines.flow.MutableStateFlow(nativeBackend.player)
     val surfacePlayer: kotlinx.coroutines.flow.StateFlow<NativeVideoPlayer> = _surfacePlayer
-    private val _preferredVideoState =
-        kotlinx.coroutines.flow.MutableStateFlow<PreferredVideoState>(PreferredVideoState.BackendUnavailable)
-    val preferredVideoState: kotlinx.coroutines.flow.StateFlow<PreferredVideoState> = _preferredVideoState
+    private val _videoPreferred = kotlinx.coroutines.flow.MutableStateFlow(false)
+    val videoPreferred: kotlinx.coroutines.flow.StateFlow<Boolean> = _videoPreferred
+    private val preferredLookup =
+        PreferredVideoLookupCoordinator(
+            store = preferredVideoStore,
+            scope = scope,
+            canLookup = { nowPlayingVisible || _videoPreferred.value },
+            currentPosition = { audio.queue.value.toVideoQueuePosition() },
+            resumeAudio = audio::play,
+            onResolved = ::applyVideoPreference,
+        )
+    val preferredVideoState: kotlinx.coroutines.flow.StateFlow<PreferredVideoState> = preferredLookup.state
     private val returnToNowPlayingChannel = Channel<Unit>(capacity = Channel.BUFFERED)
     val returnToNowPlayingEvents: Flow<Unit> = returnToNowPlayingChannel.receiveAsFlow()
 
     private var searchJob: Job? = null
-    private var preferredLookupJob: Job? = null
     private val persistenceMutex = Mutex()
-    private var preferredLookupGeneration = 0L
     private var generation = 0L
     private var nowPlayingVisible = false
     private var activeCandidate: VideoCandidate? = null
     private var sessionAudioTrackId: String? = null
+    private var sessionQueuePosition: VideoQueuePosition? = null
+    private var automaticVideoSession = false
+    private var resumeAudioForNextQueuePosition = false
+    private var disclosureAction = DisclosureAction.RequestVideo
     private var recordedVideoIdForSession: String? = null
     private var playbackPersistenceAction: PlaybackPersistenceAction = PlaybackPersistenceAction.None
     private var lastCandidates: List<VideoCandidate> = emptyList()
@@ -54,9 +66,9 @@ class VideoViewModel(
     init {
         scope.launch {
             audio.queue
-                .map { it.currentItem?.id }
+                .map(PlaybackQueue::toVideoQueuePosition)
                 .distinctUntilChanged()
-                .collect { trackId -> onTrackChanged(trackId) }
+                .collect(::onQueuePositionChanged)
         }
         scope.launch {
             nativeBackend.player.state.collect { onPlayerState(nativeBackend.player, it) }
@@ -66,10 +78,23 @@ class VideoViewModel(
     fun setNowPlayingVisible(visible: Boolean) {
         if (nowPlayingVisible == visible) return
         nowPlayingVisible = visible
-        preferredLookupJob?.cancel()
-        if (visible) {
-            startPreferredVideoLookup(audio.queue.value.currentItem?.id)
+        preferredLookup.restart(audio.queue.value.toVideoQueuePosition())
+    }
+
+    @Suppress("ReturnCount")
+    fun toggleVideoPreferredMode() {
+        if (_videoPreferred.value) {
+            disableVideoPreferredMode()
+            return
         }
+        val position = audio.queue.value.toVideoQueuePosition()?.takeIf { it.isPlaylist } ?: return
+        if (!consentStore.isAccepted()) {
+            generation += 1
+            disclosureAction = DisclosureAction.EnableVideoPreferred
+            _uiState.value = VideoUiState.ConsentRequired(position.trackId, generation)
+            return
+        }
+        enableVideoPreferredMode(position)
     }
 
     fun onVideoAction() {
@@ -91,6 +116,7 @@ class VideoViewModel(
         generation += 1
         val requestGeneration = generation
         if (!consentStore.isAccepted()) {
+            disclosureAction = DisclosureAction.RequestVideo
             _uiState.value = VideoUiState.ConsentRequired(track.id, requestGeneration)
             return
         }
@@ -100,13 +126,25 @@ class VideoViewModel(
     @Suppress("ReturnCount")
     fun acceptDisclosure() {
         val state = _uiState.value as? VideoUiState.ConsentRequired ?: return
-        if (audio.queue.value.currentItem?.id != state.trackId) return
+        if (audio.queue.value.currentItem?.id != state.trackId) {
+            disclosureAction = DisclosureAction.RequestVideo
+            return
+        }
         consentStore.accept()
-        startKnownVideoOrSearch(state.trackId, state.generation)
+        val acceptedAction = disclosureAction
+        disclosureAction = DisclosureAction.RequestVideo
+        when (acceptedAction) {
+            DisclosureAction.RequestVideo -> startKnownVideoOrSearch(state.trackId, state.generation)
+            DisclosureAction.EnableVideoPreferred -> {
+                val position = audio.queue.value.toVideoQueuePosition()?.takeIf { it.isPlaylist } ?: return
+                enableVideoPreferredMode(position)
+            }
+        }
     }
 
     fun cancelDisclosure() {
         if (_uiState.value is VideoUiState.ConsentRequired) {
+            disclosureAction = DisclosureAction.RequestVideo
             _uiState.value = availableIdleState()
         }
     }
@@ -119,11 +157,11 @@ class VideoViewModel(
             trackId = track.id,
             boundAudioTrackId = track.id,
             persistenceAction = PlaybackPersistenceAction.SaveMapping(track.id),
+            enableVideoPreferred = true,
         )
     }
 
     fun playHistory(entry: VideoHistoryEntry) {
-        generation += 1
         val audioTrackId = audio.queue.value.currentItem?.id
         startCandidate(
             candidate = entry.toVideoCandidate(),
@@ -137,13 +175,14 @@ class VideoViewModel(
         trackId: String,
         requestGeneration: Long,
     ) {
-        val preferred = _preferredVideoState.value
+        val preferred = preferredVideoState.value
         if (preferred is PreferredVideoState.Mapped && preferred.trackId == trackId) {
             startCandidate(
                 candidate = preferred.candidate,
                 trackId = trackId,
                 boundAudioTrackId = trackId,
                 persistenceAction = PlaybackPersistenceAction.MarkPlayed(trackId),
+                enableVideoPreferred = true,
             )
         } else {
             search(trackId, requestGeneration)
@@ -155,11 +194,24 @@ class VideoViewModel(
         trackId: String,
         boundAudioTrackId: String?,
         persistenceAction: PlaybackPersistenceAction,
+        enableVideoPreferred: Boolean = false,
+        automatic: Boolean = false,
     ) {
         if (_uiState.value.isVideoSessionActive) releaseVideoPlayer()
+        generation += 1
+        val queuePosition = audio.queue.value.toVideoQueuePosition()
+        if (
+            enableVideoPreferred &&
+            queuePosition?.isPlaylist == true &&
+            queuePosition.trackId == trackId
+        ) {
+            _videoPreferred.value = true
+        }
         audio.pause()
         activeCandidate = candidate
         sessionAudioTrackId = boundAudioTrackId
+        sessionQueuePosition = queuePosition
+        automaticVideoSession = automatic
         recordedVideoIdForSession = null
         playbackPersistenceAction = persistenceAction
         val session = VideoSessionKey(trackId, generation)
@@ -273,6 +325,8 @@ class VideoViewModel(
         releaseVideoPlayer()
         activeCandidate = null
         sessionAudioTrackId = null
+        sessionQueuePosition = null
+        automaticVideoSession = false
         recordedVideoIdForSession = null
         playbackPersistenceAction = PlaybackPersistenceAction.None
         lastCandidates = emptyList()
@@ -281,16 +335,9 @@ class VideoViewModel(
         if (hadActiveSession) returnToNowPlayingChannel.trySend(Unit)
     }
 
-    fun closeForQueueChange() {
-        releaseVideoPlayer()
-        activeCandidate = null
-        sessionAudioTrackId = null
-        recordedVideoIdForSession = null
-        playbackPersistenceAction = PlaybackPersistenceAction.None
-        lastCandidates = emptyList()
-        generation += 1
-        _uiState.value = availableIdleState()
-    }
+    fun nextTrack(): Boolean = moveFromVideoToQueue(audio::next)
+
+    fun previousTrack(): Boolean = moveFromVideoToQueue(audio::previous)
 
     fun onAppBackgrounded() {
         if (_uiState.value is VideoUiState.Playing) activePlayer().pause()
@@ -347,47 +394,38 @@ class VideoViewModel(
         }
     }
 
-    private fun startPreferredVideoLookup(trackId: String?) {
-        preferredLookupJob?.cancel()
-        preferredLookupGeneration += 1L
-        val lookupGeneration = preferredLookupGeneration
-        if (!nowPlayingVisible || trackId == null) {
-            _preferredVideoState.value = PreferredVideoState.BackendUnavailable
-            return
+    private fun onQueuePositionChanged(position: VideoQueuePosition?) {
+        val videoWasActive = _uiState.value.isVideoSessionActive
+        val requestTrackChanged =
+            sessionQueuePosition == null &&
+                _uiState.value.trackId?.let { it != position?.trackId } == true
+        val sessionTrackChanged =
+            sessionQueuePosition?.representsSameTrack(position) == false
+        if (sessionTrackChanged || requestTrackChanged) {
+            clearVideoSession()
         }
-        _preferredVideoState.value = PreferredVideoState.Checking(trackId)
-        preferredLookupJob =
-            scope.launch {
-                val result = preferredVideoStore.lookup(trackId)
-                if (
-                    lookupGeneration != preferredLookupGeneration ||
-                    !nowPlayingVisible ||
-                    audio.queue.value.currentItem?.id != trackId
-                ) {
-                    return@launch
-                }
-                _preferredVideoState.value =
-                    when (result) {
-                        is PreferredVideoLookupResult.Found ->
-                            if (result.video.trackId == trackId && result.video.provider == YOUTUBE_PROVIDER) {
-                                PreferredVideoState.Mapped(trackId, result.video.toVideoCandidate())
-                            } else {
-                                PreferredVideoState.BackendUnavailable
-                            }
-                        PreferredVideoLookupResult.Missing -> PreferredVideoState.Unmapped(trackId)
-                        PreferredVideoLookupResult.BackendUnavailable -> PreferredVideoState.BackendUnavailable
-                    }
+        val resumeAudio = resumeAudioForNextQueuePosition || (videoWasActive && _videoPreferred.value)
+        resumeAudioForNextQueuePosition = false
+        if (position?.isPlaylist != true) _videoPreferred.value = false
+        if (_videoPreferred.value && position != null) {
+            preferredLookup.restart(position, resumeAudioIfMissing = resumeAudio)
+        } else {
+            if (resumeAudio) audio.play()
+            if (nowPlayingVisible) {
+                preferredLookup.restart(position)
+            } else {
+                preferredLookup.cancelAndReset()
             }
+        }
     }
 
-    private fun onTrackChanged(trackId: String?) {
-        if (nowPlayingVisible) startPreferredVideoLookup(trackId)
-        val trackedAudioId = sessionAudioTrackId ?: _uiState.value.trackId ?: return
-        if (trackedAudioId == trackId) return
+    private fun clearVideoSession() {
         searchJob?.cancel()
         releaseVideoPlayer()
         activeCandidate = null
         sessionAudioTrackId = null
+        sessionQueuePosition = null
+        automaticVideoSession = false
         recordedVideoIdForSession = null
         playbackPersistenceAction = PlaybackPersistenceAction.None
         lastCandidates = emptyList()
@@ -481,7 +519,7 @@ class VideoViewModel(
                     nowPlayingVisible &&
                     audio.queue.value.currentItem?.id == action.trackId
                 ) {
-                    _preferredVideoState.value = PreferredVideoState.Mapped(action.trackId, candidate)
+                    preferredLookup.publishMapped(action.trackId, candidate)
                 }
             }
         }
@@ -489,15 +527,16 @@ class VideoViewModel(
 
     private fun onPlayerEnded(state: NativeVideoPlayerState.Ended) {
         if (!isCurrentSession(state.session)) return
-        releaseVideoPlayer()
-        activeCandidate = null
-        sessionAudioTrackId = null
-        recordedVideoIdForSession = null
-        playbackPersistenceAction = PlaybackPersistenceAction.None
-        lastCandidates = emptyList()
-        generation += 1
-        _uiState.value = availableIdleState()
-        returnToNowPlayingChannel.trySend(Unit)
+        val shouldContinuePlaylist =
+            _videoPreferred.value &&
+                sessionAudioTrackId == audio.queue.value.currentItem?.id &&
+                audio.queue.value.toVideoQueuePosition()?.isPlaylist == true
+        if (shouldContinuePlaylist) {
+            moveFromVideoToQueue(audio::next)
+        } else {
+            clearVideoSession()
+            returnToNowPlayingChannel.trySend(Unit)
+        }
     }
 
     @Suppress("ReturnCount")
@@ -506,12 +545,24 @@ class VideoViewModel(
         state: NativeVideoPlayerState.Error,
     ) {
         if (!isCurrentSession(state.session)) return
+        val fallbackToAudio =
+            automaticVideoSession &&
+                _videoPreferred.value &&
+                sessionAudioTrackId == audio.queue.value.currentItem?.id
         source.release()
         activeCandidate = null
         sessionAudioTrackId = null
+        sessionQueuePosition = null
+        automaticVideoSession = false
         recordedVideoIdForSession = null
         playbackPersistenceAction = PlaybackPersistenceAction.None
-        _uiState.value = VideoUiState.Error(state.session.trackId, state.session.generation, state.message)
+        if (fallbackToAudio) {
+            generation += 1
+            _uiState.value = availableIdleState()
+            audio.play()
+        } else {
+            _uiState.value = VideoUiState.Error(state.session.trackId, state.session.generation, state.message)
+        }
     }
 
     private fun releaseVideoPlayer() {
@@ -534,7 +585,183 @@ class VideoViewModel(
         generation == session.generation && _uiState.value.trackId == session.trackId
 
     private fun availableIdleState(): VideoUiState = VideoUiState.Idle
+
+    private fun enableVideoPreferredMode(position: VideoQueuePosition) {
+        _videoPreferred.value = true
+        _uiState.value = availableIdleState()
+        val preferred = preferredVideoState.value
+        if (preferred is PreferredVideoState.Mapped && preferred.trackId == position.trackId) {
+            applyVideoPreference(position, preferred, resumeAudioIfMissing = false)
+        } else {
+            preferredLookup.restart(position)
+        }
+    }
+
+    private fun disableVideoPreferredMode() {
+        _videoPreferred.value = false
+        val resumeAfterLookup = preferredLookup.cancelAndTakeAudioResume()
+        resumeAudioForNextQueuePosition = false
+        val state = _uiState.value
+        val positionMs = (state as? VideoUiState.Playing)?.positionMs ?: 0L
+        val resumeCurrentAudio =
+            sessionAudioTrackId == audio.queue.value.currentItem?.id &&
+                audio.queue.value.toVideoQueuePosition()?.isPlaylist == true
+        if (state.isVideoSessionActive || resumeCurrentAudio) clearVideoSession()
+        if (resumeCurrentAudio) {
+            audio.seekTo(positionMs)
+            audio.play()
+            returnToNowPlayingChannel.trySend(Unit)
+        } else if (resumeAfterLookup) {
+            audio.play()
+        }
+        if (nowPlayingVisible) preferredLookup.restart(audio.queue.value.toVideoQueuePosition())
+    }
+
+    private fun applyVideoPreference(
+        position: VideoQueuePosition,
+        preferred: PreferredVideoState,
+        resumeAudioIfMissing: Boolean,
+    ) {
+        val canStartVideo =
+            _videoPreferred.value &&
+                position.isPlaylist &&
+                audio.queue.value.toVideoQueuePosition() == position &&
+                _uiState.value is VideoUiState.Idle
+        if (canStartVideo && preferred is PreferredVideoState.Mapped) {
+            startCandidate(
+                candidate = preferred.candidate,
+                trackId = position.trackId,
+                boundAudioTrackId = position.trackId,
+                persistenceAction = PlaybackPersistenceAction.MarkPlayed(position.trackId),
+                automatic = true,
+            )
+        } else if (resumeAudioIfMissing) {
+            audio.play()
+        }
+    }
+
+    private fun moveFromVideoToQueue(move: () -> Unit): Boolean {
+        if (!_uiState.value.isVideoSessionActive) return false
+        val before = audio.queue.value.toVideoQueuePosition()
+        val continueVideoPreference = _videoPreferred.value && before?.isPlaylist == true
+        clearVideoSession()
+        resumeAudioForNextQueuePosition = continueVideoPreference
+        move()
+        if (audio.queue.value.toVideoQueuePosition() == before) {
+            resumeAudioForNextQueuePosition = false
+            returnToNowPlayingChannel.trySend(Unit)
+        }
+        return true
+    }
 }
+
+private class PreferredVideoLookupCoordinator(
+    private val store: PreferredVideoStore,
+    private val scope: CoroutineScope,
+    private val canLookup: () -> Boolean,
+    private val currentPosition: () -> VideoQueuePosition?,
+    private val resumeAudio: () -> Unit,
+    private val onResolved: (VideoQueuePosition, PreferredVideoState, Boolean) -> Unit,
+) {
+    private val mutableState =
+        kotlinx.coroutines.flow.MutableStateFlow<PreferredVideoState>(PreferredVideoState.BackendUnavailable)
+    val state: kotlinx.coroutines.flow.StateFlow<PreferredVideoState> = mutableState
+
+    private var job: Job? = null
+    private var generation = 0L
+    private var pendingAudioResume = false
+
+    fun restart(
+        position: VideoQueuePosition?,
+        resumeAudioIfMissing: Boolean = false,
+    ) {
+        val carryAudioResume = resumeAudioIfMissing || pendingAudioResume
+        cancelCurrent()
+        if (!canLookup() || position == null) {
+            pendingAudioResume = false
+            mutableState.value = PreferredVideoState.BackendUnavailable
+            if (carryAudioResume) resumeAudio()
+            return
+        }
+        pendingAudioResume = carryAudioResume
+        mutableState.value = PreferredVideoState.Checking(position.trackId)
+        val requestGeneration = generation
+        job =
+            scope.launch {
+                val result = store.lookup(position.trackId)
+                if (
+                    requestGeneration != generation ||
+                    !canLookup() ||
+                    currentPosition() != position
+                ) {
+                    return@launch
+                }
+                pendingAudioResume = false
+                val preferredState = result.toPreferredVideoState(position.trackId)
+                mutableState.value = preferredState
+                onResolved(position, preferredState, carryAudioResume)
+            }
+    }
+
+    fun cancelAndTakeAudioResume(): Boolean {
+        val resume = pendingAudioResume
+        cancelCurrent()
+        pendingAudioResume = false
+        return resume
+    }
+
+    fun cancelAndReset() {
+        cancelCurrent()
+        pendingAudioResume = false
+        mutableState.value = PreferredVideoState.BackendUnavailable
+    }
+
+    fun publishMapped(
+        trackId: String,
+        candidate: VideoCandidate,
+    ) {
+        mutableState.value = PreferredVideoState.Mapped(trackId, candidate)
+    }
+
+    private fun cancelCurrent() {
+        job?.cancel()
+        generation += 1L
+    }
+}
+
+private data class VideoQueuePosition(
+    val trackId: String,
+    val index: Int,
+    val sourcePlaylistName: String?,
+    val queueTrackIds: List<String>,
+) {
+    val isPlaylist: Boolean = !sourcePlaylistName.isNullOrBlank()
+
+    fun representsSameTrack(other: VideoQueuePosition?): Boolean =
+        trackId == other?.trackId && sourcePlaylistName == other.sourcePlaylistName
+}
+
+private fun PlaybackQueue.toVideoQueuePosition(): VideoQueuePosition? {
+    val track = currentItem ?: return null
+    return VideoQueuePosition(
+        trackId = track.id,
+        index = currentIndex,
+        sourcePlaylistName = sourcePlaylistName,
+        queueTrackIds = items.map { it.id },
+    )
+}
+
+private fun PreferredVideoLookupResult.toPreferredVideoState(trackId: String): PreferredVideoState =
+    when (this) {
+        is PreferredVideoLookupResult.Found ->
+            if (video.trackId == trackId && video.provider == YOUTUBE_PROVIDER) {
+                PreferredVideoState.Mapped(trackId, video.toVideoCandidate())
+            } else {
+                PreferredVideoState.BackendUnavailable
+            }
+        PreferredVideoLookupResult.Missing -> PreferredVideoState.Unmapped(trackId)
+        PreferredVideoLookupResult.BackendUnavailable -> PreferredVideoState.BackendUnavailable
+    }
 
 private fun NativeVideoPlayerState.sessionOrNull(): VideoSessionKey? =
     when (this) {
@@ -575,6 +802,11 @@ private sealed interface PlaybackPersistenceAction {
     data class SaveMapping(val trackId: String) : PlaybackPersistenceAction
 
     data class MarkPlayed(val trackId: String) : PlaybackPersistenceAction
+}
+
+private enum class DisclosureAction {
+    RequestVideo,
+    EnableVideoPreferred,
 }
 
 private const val YOUTUBE_SEARCH_RESULT_LIMIT = 25

--- a/feature/video/src/test/java/com/tuneflow/feature/video/VideoViewModelTest.kt
+++ b/feature/video/src/test/java/com/tuneflow/feature/video/VideoViewModelTest.kt
@@ -380,6 +380,185 @@ class VideoViewModelTest {
             assertTrue(viewModel.uiState.value is VideoUiState.Idle)
         }
 
+    @Test
+    fun selectingVideoFromPlaylistEnablesVideoPreference() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val viewModel = createViewModel(audio, backgroundScope)
+            runCurrent()
+
+            viewModel.requestVideo()
+            runCurrent()
+            viewModel.selectCandidate((viewModel.uiState.value as VideoUiState.Candidates).candidates.first())
+
+            assertTrue(viewModel.videoPreferred.value)
+            assertTrue(viewModel.uiState.value is VideoUiState.Loading)
+        }
+
+    @Test
+    fun selectingVideoOutsidePlaylistKeepsAudioOnlyMode() =
+        runTest {
+            val audio = VideoViewModelFakeAudio()
+            val viewModel = createViewModel(audio, backgroundScope)
+            runCurrent()
+
+            viewModel.requestVideo()
+            runCurrent()
+            viewModel.selectCandidate((viewModel.uiState.value as VideoUiState.Candidates).candidates.first())
+
+            assertFalse(viewModel.videoPreferred.value)
+        }
+
+    @Test
+    fun completedVideoAdvancesPlaylistAndStartsNextPreferredVideo() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val nativePlayer = FakeNativePlayer()
+            val store =
+                FakePreferredVideoStore(
+                    lookupResults =
+                        mapOf(
+                            "next" to
+                                PreferredVideoLookupResult.Found(
+                                    historyEntry("next", "nextvideo01"),
+                                ),
+                        ),
+                )
+            val viewModel = createViewModel(audio, backgroundScope, FakeNativeBackend(nativePlayer), store)
+            runCurrent()
+
+            viewModel.requestVideo()
+            runCurrent()
+            viewModel.selectCandidate((viewModel.uiState.value as VideoUiState.Candidates).candidates.first())
+            nativePlayer.emitEnded()
+            runCurrent()
+
+            assertEquals("next", audio.queue.value.currentItem?.id)
+            assertEquals(listOf("next"), store.lookupTrackIds)
+            val loading = viewModel.uiState.value as VideoUiState.Loading
+            assertEquals("nextvideo01", loading.candidate.videoId)
+            assertEquals(0, audio.playCalls)
+            assertTrue(viewModel.videoPreferred.value)
+        }
+
+    @Test
+    fun completedVideoFallsBackToAudioWhenNextTrackHasNoPreferredVideo() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val nativePlayer = FakeNativePlayer()
+            val viewModel = createViewModel(audio, backgroundScope, FakeNativeBackend(nativePlayer))
+            runCurrent()
+
+            viewModel.requestVideo()
+            runCurrent()
+            viewModel.selectCandidate((viewModel.uiState.value as VideoUiState.Candidates).candidates.first())
+            nativePlayer.emitEnded()
+            runCurrent()
+
+            assertEquals("next", audio.queue.value.currentItem?.id)
+            assertTrue(viewModel.uiState.value is VideoUiState.Idle)
+            assertEquals(1, audio.playCalls)
+            assertTrue(audio.isPlaying.value)
+            assertTrue(viewModel.videoPreferred.value)
+        }
+
+    @Test
+    fun preferredVideoModeStartsMappedVideoAfterAudioAdvances() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val store =
+                FakePreferredVideoStore(
+                    lookupResults =
+                        mapOf(
+                            "track" to PreferredVideoLookupResult.Missing,
+                            "next" to
+                                PreferredVideoLookupResult.Found(
+                                    historyEntry("next", "nextvideo01"),
+                                ),
+                        ),
+                )
+            val viewModel = createViewModel(audio, backgroundScope, preferredVideoStore = store)
+            runCurrent()
+
+            viewModel.toggleVideoPreferredMode()
+            runCurrent()
+            audio.next()
+            runCurrent()
+
+            val loading = viewModel.uiState.value as VideoUiState.Loading
+            assertEquals("nextvideo01", loading.candidate.videoId)
+            assertEquals(listOf("track", "next"), store.lookupTrackIds)
+            assertTrue(viewModel.videoPreferred.value)
+        }
+
+    @Test
+    fun disablingVideoPreferenceSwitchesActiveVideoBackToAudioPosition() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val nativePlayer = FakeNativePlayer()
+            val viewModel = createViewModel(audio, backgroundScope, FakeNativeBackend(nativePlayer))
+            runCurrent()
+
+            viewModel.requestVideo()
+            runCurrent()
+            viewModel.selectCandidate((viewModel.uiState.value as VideoUiState.Candidates).candidates.first())
+            nativePlayer.emitPlaying(positionMs = 42_000L, durationMs = 180_000L)
+            runCurrent()
+
+            viewModel.toggleVideoPreferredMode()
+
+            assertFalse(viewModel.videoPreferred.value)
+            assertTrue(viewModel.uiState.value is VideoUiState.Idle)
+            assertEquals(42_000L, audio.seekPositionMs)
+            assertEquals(1, audio.playCalls)
+            assertTrue(audio.isPlaying.value)
+        }
+
+    @Test
+    fun automaticPreferredVideoFailureFallsBackToAudio() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val nativePlayer = FakeNativePlayer()
+            val store =
+                FakePreferredVideoStore(
+                    lookupResult =
+                        PreferredVideoLookupResult.Found(
+                            historyEntry("track", "mappedvid01"),
+                        ),
+                )
+            val viewModel = createViewModel(audio, backgroundScope, FakeNativeBackend(nativePlayer), store)
+            runCurrent()
+
+            viewModel.toggleVideoPreferredMode()
+            runCurrent()
+            nativePlayer.emitError("Native resolver failed.")
+            runCurrent()
+
+            assertTrue(viewModel.videoPreferred.value)
+            assertTrue(viewModel.uiState.value is VideoUiState.Idle)
+            assertEquals(1, audio.playCalls)
+            assertTrue(audio.isPlaying.value)
+        }
+
+    @Test
+    fun disabledVideoPreferenceLeavesFollowingPlaylistTracksOnAudio() =
+        runTest {
+            val audio = VideoViewModelFakeAudio(playlistQueue("track", "next"))
+            val store = FakePreferredVideoStore()
+            val viewModel = createViewModel(audio, backgroundScope, preferredVideoStore = store)
+            runCurrent()
+
+            viewModel.toggleVideoPreferredMode()
+            runCurrent()
+            viewModel.toggleVideoPreferredMode()
+            audio.next()
+            runCurrent()
+
+            assertFalse(viewModel.videoPreferred.value)
+            assertTrue(viewModel.uiState.value is VideoUiState.Idle)
+            assertEquals(listOf("track"), store.lookupTrackIds)
+        }
+
     private fun createViewModel(
         audio: VideoViewModelFakeAudio,
         scope: CoroutineScope,
@@ -502,11 +681,16 @@ private class FakeNativePlayer : NativeVideoPlayer {
     ) {
         mutableState.value = NativeVideoPlayerState.Playing(requireNotNull(session), positionMs, durationMs)
     }
+
+    fun emitEnded() {
+        mutableState.value = NativeVideoPlayerState.Ended(requireNotNull(session), 180_000L, 180_000L)
+    }
 }
 
 private class FakePreferredVideoStore(
     var lookupResult: PreferredVideoLookupResult = PreferredVideoLookupResult.Missing,
     private val lookupDelayMs: Long = 0L,
+    private val lookupResults: Map<String, PreferredVideoLookupResult> = emptyMap(),
 ) : PreferredVideoStore {
     override val history: StateFlow<List<VideoHistoryEntry>> = MutableStateFlow(emptyList())
     val lookupTrackIds = mutableListOf<String>()
@@ -516,7 +700,7 @@ private class FakePreferredVideoStore(
     override suspend fun lookup(trackId: String): PreferredVideoLookupResult {
         lookupTrackIds += trackId
         delay(lookupDelayMs)
-        return lookupResult
+        return lookupResults[trackId] ?: lookupResult
     }
 
     override suspend fun savePreferredVideo(
@@ -571,14 +755,17 @@ private object AcceptedConsentStore : VideoConsentStore {
     override fun accept() = Unit
 }
 
-private class VideoViewModelFakeAudio : PlaybackController {
-    private val queueState = MutableStateFlow(queueFor("track"))
+private class VideoViewModelFakeAudio(
+    initialQueue: PlaybackQueue = queueFor("track"),
+) : PlaybackController {
+    private val queueState = MutableStateFlow(initialQueue)
     private val playingState = MutableStateFlow(true)
     private val statusState = MutableStateFlow(PlaybackStatus())
     private val modeState = MutableStateFlow(PlaybackMode.Default)
 
     var pauseCalls = 0
     var playCalls = 0
+    var seekPositionMs: Long? = null
 
     override val queue: StateFlow<PlaybackQueue> = queueState
     override val isPlaying: StateFlow<Boolean> = playingState
@@ -595,11 +782,17 @@ private class VideoViewModelFakeAudio : PlaybackController {
         playingState.value = false
     }
 
-    override fun next() = Unit
+    override fun next() {
+        queueState.value = queueState.value.next()
+    }
 
-    override fun previous() = Unit
+    override fun previous() {
+        queueState.value = queueState.value.previous()
+    }
 
-    override fun seekTo(positionMs: Long) = Unit
+    override fun seekTo(positionMs: Long) {
+        seekPositionMs = positionMs
+    }
 
     override fun playFromIndex(index: Int) = Unit
 
@@ -634,3 +827,19 @@ private class VideoViewModelFakeAudio : PlaybackController {
             )
     }
 }
+
+private fun playlistQueue(vararg trackIds: String): PlaybackQueue =
+    PlaybackQueue(
+        items =
+            trackIds.map { id ->
+                QueueItem(
+                    id = id,
+                    title = "Track $id",
+                    artist = "Artist",
+                    album = "Album",
+                    streamUrl = "stream/$id",
+                    durationMs = 180_000L,
+                )
+            },
+        sourcePlaylistName = "Playlist",
+    )


### PR DESCRIPTION
## Summary

- add a D-pad-friendly Video preferred toggle to Now Playing for playlist queues
- automatically enable video preference when the user starts a video from a playlist
- continue the playlist after video completion, using each saved preferred video when available and audio otherwise
- fall back to audio when automatic video playback fails, and resume audio at the matching position when the mode is disabled
- route media next and previous through the same queue-aware video transition flow
- document the playlist video mode and expand regression coverage

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt`