### PR TITLE
feat(playback): scrobble completed audio and video listens

### DIFF
--- a/app/src/main/java/com/tuneflow/tv/MainActivity.kt
+++ b/app/src/main/java/com/tuneflow/tv/MainActivity.kt
@@ -79,7 +79,9 @@ class MainActivity : ComponentActivity() {
         val authRepository = AuthRepository(sessionStore)
         val browseRepository = BrowseRepository(sessionStore)
         val lyricsRepository = LyricsRepository(sessionStore)
+        val scrobbleReporter = NavidromeScrobbleReporter(sessionStore)
         playerManager = PlayerGraph.get(applicationContext)
+        playerManager.setScrobbleReporter(scrobbleReporter)
         playbackServiceIntent = Intent(this, TuneFlowPlaybackService::class.java)
         startService(playbackServiceIntent)
 
@@ -117,6 +119,7 @@ class MainActivity : ComponentActivity() {
                         playbackPreferencesStore = playbackPreferencesStore,
                         searchHistoryStore = searchHistoryStore,
                         lyricsRepository = lyricsRepository,
+                        scrobbleReporter = scrobbleReporter,
                         preferredVideoStore = preferredVideoStore,
                         preferredVideoServiceUrl = preferredVideoServiceUrl,
                         onPreferredVideoServiceUrlChanged = { serviceUrl ->
@@ -418,6 +421,7 @@ private fun TuneFlowShell(
     playbackPreferencesStore: PlaybackPreferencesStore,
     searchHistoryStore: SearchHistoryStore,
     lyricsRepository: LyricsRepository,
+    scrobbleReporter: com.tuneflow.core.player.ScrobbleReporter,
     preferredVideoStore: PreferredVideoStore,
     preferredVideoServiceUrl: String,
     onPreferredVideoServiceUrlChanged: (String) -> Unit,
@@ -449,6 +453,7 @@ private fun TuneFlowShell(
                     androidx.compose.ui.platform.LocalContext.current,
                     playerManager,
                     preferredVideoStore,
+                    scrobbleReporter,
                 ),
         )
     val playbackState by playbackViewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/tuneflow/tv/NavidromeScrobbleReporter.kt
+++ b/app/src/main/java/com/tuneflow/tv/NavidromeScrobbleReporter.kt
@@ -1,0 +1,48 @@
+package com.tuneflow.tv
+
+import android.util.Log
+import com.tuneflow.core.network.DefaultNavidromeClientProvider
+import com.tuneflow.core.network.NavidromeClientProvider
+import com.tuneflow.core.network.NetworkFactory
+import com.tuneflow.core.network.NetworkResult
+import com.tuneflow.core.network.SessionData
+import com.tuneflow.core.network.SessionStore
+import com.tuneflow.core.player.ScrobbleReporter
+import com.tuneflow.core.player.ScrobbleSubmission
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal class NavidromeScrobbleReporter(
+    private val currentSession: () -> SessionData?,
+    private val clientProvider: NavidromeClientProvider = DefaultNavidromeClientProvider,
+    private val diagnostic: (String) -> Unit = { message -> Log.w(SCROBBLE_LOG_TAG, message) },
+) : ScrobbleReporter {
+    constructor(sessionStore: SessionStore) : this(currentSession = { sessionStore.sessionState.value })
+
+    override fun currentAccountKey(): String? = currentSession()?.let { session -> runCatching { session.accountKey() }.getOrNull() }
+
+    override suspend fun scrobble(submission: ScrobbleSubmission) {
+        val session = currentSession()
+        if (session != null && runCatching { session.accountKey() }.getOrNull() == submission.accountKey) {
+            val result =
+                try {
+                    withContext(Dispatchers.IO) {
+                        clientProvider.create(session).scrobble(
+                            trackId = submission.trackId,
+                            startedAtEpochMs = submission.startedAtEpochMs,
+                        )
+                    }
+                } catch (error: IllegalArgumentException) {
+                    diagnostic("Navidrome scrobble failed; playback continues: ${error.message.orEmpty()}")
+                    null
+                }
+            if (result is NetworkResult.Error) {
+                diagnostic("Navidrome scrobble failed; playback continues: ${result.message}")
+            }
+        }
+    }
+}
+
+private fun SessionData.accountKey(): String = "${NetworkFactory.normalizeBaseUrl(serverUrl)}\u0000$username"
+
+private const val SCROBBLE_LOG_TAG = "TuneFlowScrobble"

--- a/app/src/main/java/com/tuneflow/tv/ViewModelFactories.kt
+++ b/app/src/main/java/com/tuneflow/tv/ViewModelFactories.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.tuneflow.core.network.SearchHistoryStore
 import com.tuneflow.core.network.SessionStore
+import com.tuneflow.core.player.ScrobbleReporter
 import com.tuneflow.core.player.TvPlayerManager
 import com.tuneflow.feature.auth.AuthRepository
 import com.tuneflow.feature.auth.AuthViewModel
@@ -78,6 +79,7 @@ fun videoViewModelFactory(
     context: Context,
     manager: TvPlayerManager,
     preferredVideoStore: PreferredVideoStore,
+    scrobbleReporter: ScrobbleReporter,
 ) = viewModelFactory {
     initializer {
         VideoViewModel(
@@ -85,6 +87,7 @@ fun videoViewModelFactory(
             consentStore = SharedPreferencesVideoConsentStore(context),
             nativeBackend = createNativeVideoBackend(context),
             preferredVideoStore = preferredVideoStore,
+            scrobbleReporter = scrobbleReporter,
         )
     }
 }

--- a/app/src/test/java/com/tuneflow/tv/NavidromeScrobbleReporterTest.kt
+++ b/app/src/test/java/com/tuneflow/tv/NavidromeScrobbleReporterTest.kt
@@ -1,0 +1,98 @@
+package com.tuneflow.tv
+
+import com.tuneflow.core.network.NavidromeClient
+import com.tuneflow.core.network.NavidromeClientProvider
+import com.tuneflow.core.network.NetworkResult
+import com.tuneflow.core.network.SessionData
+import com.tuneflow.core.player.ScrobbleSubmission
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavidromeScrobbleReporterTest {
+    @Test
+    fun `matching account submits original track and timestamp`() =
+        runTest {
+            val session = session("user")
+            val client = RecordingNavidromeClient(session)
+            val reporter =
+                NavidromeScrobbleReporter(
+                    currentSession = { session },
+                    clientProvider = NavidromeClientProvider { client },
+                    diagnostic = {},
+                )
+            val accountKey = requireNotNull(reporter.currentAccountKey())
+
+            reporter.scrobble(ScrobbleSubmission(accountKey, "track-id", 1_234_567L))
+
+            assertEquals(listOf("track-id" to 1_234_567L), client.submissions)
+        }
+
+    @Test
+    fun `changed account discards submission`() =
+        runTest {
+            var activeSession = session("first")
+            val client = RecordingNavidromeClient(activeSession)
+            val reporter =
+                NavidromeScrobbleReporter(
+                    currentSession = { activeSession },
+                    clientProvider = NavidromeClientProvider { client },
+                    diagnostic = {},
+                )
+            val originalAccountKey = requireNotNull(reporter.currentAccountKey())
+            activeSession = session("second")
+
+            reporter.scrobble(ScrobbleSubmission(originalAccountKey, "track-id", 1_234_567L))
+
+            assertTrue(client.submissions.isEmpty())
+        }
+
+    @Test
+    fun `server failure is diagnostic only`() =
+        runTest {
+            val session = session("user")
+            val diagnostics = mutableListOf<String>()
+            val client = RecordingNavidromeClient(session, NetworkResult.Error("offline"))
+            val reporter =
+                NavidromeScrobbleReporter(
+                    currentSession = { session },
+                    clientProvider = NavidromeClientProvider { client },
+                    diagnostic = diagnostics::add,
+                )
+
+            reporter.scrobble(
+                ScrobbleSubmission(
+                    accountKey = requireNotNull(reporter.currentAccountKey()),
+                    trackId = "track-id",
+                    startedAtEpochMs = 1_234_567L,
+                ),
+            )
+
+            assertEquals(1, diagnostics.size)
+            assertTrue(diagnostics.single().contains("playback continues"))
+        }
+
+    private fun session(username: String) =
+        SessionData(
+            serverUrl = "https://music.example.com",
+            username = username,
+            token = "token",
+            salt = "salt",
+        )
+}
+
+private class RecordingNavidromeClient(
+    session: SessionData,
+    private val result: NetworkResult<Unit> = NetworkResult.Success(Unit),
+) : NavidromeClient(session) {
+    val submissions = mutableListOf<Pair<String, Long>>()
+
+    override suspend fun scrobble(
+        trackId: String,
+        startedAtEpochMs: Long,
+    ): NetworkResult<Unit> {
+        submissions += trackId to startedAtEpochMs
+        return result
+    }
+}

--- a/core/network/src/main/java/com/tuneflow/core/network/NavidromeApi.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NavidromeApi.kt
@@ -348,4 +348,17 @@ interface NavidromeApi {
         @Query("c") client: String = CLIENT_NAME,
         @Query("f") format: String = FORMAT,
     ): SubsonicEnvelope<LegacyLyricsResponse>
+
+    @GET("rest/scrobble.view")
+    suspend fun scrobble(
+        @Query("id") trackId: String,
+        @Query("time") startedAtEpochMs: Long,
+        @Query("submission") submission: Boolean = true,
+        @Query("u") username: String,
+        @Query("t") token: String,
+        @Query("s") salt: String,
+        @Query("v") version: String = API_VERSION,
+        @Query("c") client: String = CLIENT_NAME,
+        @Query("f") format: String = FORMAT,
+    ): SubsonicEnvelope<BaseResponse>
 }

--- a/core/network/src/main/java/com/tuneflow/core/network/NavidromeClient.kt
+++ b/core/network/src/main/java/com/tuneflow/core/network/NavidromeClient.kt
@@ -246,6 +246,31 @@ open class NavidromeClient(private val session: SessionData) {
         }
     }
 
+    open suspend fun scrobble(
+        trackId: String,
+        startedAtEpochMs: Long,
+    ): NetworkResult<Unit> {
+        return safeCall {
+            val response =
+                api.scrobble(
+                    trackId = trackId,
+                    startedAtEpochMs = startedAtEpochMs,
+                    username = session.username,
+                    token = session.token,
+                    salt = session.salt,
+                ).response
+
+            if (response.status != "ok") {
+                NetworkResult.Error(
+                    message = response.error?.message ?: "Failed to scrobble track.",
+                    code = response.error?.code,
+                )
+            } else {
+                NetworkResult.Success(Unit)
+            }
+        }
+    }
+
     open fun streamOptions(trackId: String): TrackStreamOptions {
         val base =
             "${session.serverUrl}/rest/stream.view" +

--- a/core/network/src/test/java/com/tuneflow/core/network/NavidromeApiIntegrationTest.kt
+++ b/core/network/src/test/java/com/tuneflow/core/network/NavidromeApiIntegrationTest.kt
@@ -51,4 +51,78 @@ class NavidromeApiIntegrationTest {
 
         server.shutdown()
     }
+
+    @Test
+    fun scrobble_sendsSubmissionWithOriginalStartTime() {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                {
+                  "subsonic-response": {
+                    "status": "ok",
+                    "version": "1.16.1"
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+        server.start()
+
+        val client =
+            NavidromeClient(
+                SessionData(
+                    serverUrl = server.url("/").toString(),
+                    username = "user",
+                    token = "token",
+                    salt = "salt",
+                ),
+            )
+        val result = kotlinx.coroutines.runBlocking { client.scrobble("track/string-id", 1_725_000_123_456L) }
+
+        assertTrue(result is NetworkResult.Success)
+        val requestUrl = requireNotNull(server.takeRequest().requestUrl)
+        assertEquals("/rest/scrobble.view", requestUrl.encodedPath)
+        assertEquals("track/string-id", requestUrl.queryParameter("id"))
+        assertEquals("1725000123456", requestUrl.queryParameter("time"))
+        assertEquals("true", requestUrl.queryParameter("submission"))
+        assertEquals("user", requestUrl.queryParameter("u"))
+
+        server.shutdown()
+    }
+
+    @Test
+    fun scrobble_returnsServerErrorWithoutThrowing() {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                {
+                  "subsonic-response": {
+                    "status": "failed",
+                    "version": "1.16.1",
+                    "error": {"code": 70, "message": "Track not found"}
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+        server.start()
+
+        val client =
+            NavidromeClient(
+                SessionData(
+                    serverUrl = server.url("/").toString(),
+                    username = "user",
+                    token = "token",
+                    salt = "salt",
+                ),
+            )
+        val result = kotlinx.coroutines.runBlocking { client.scrobble("missing-track", 1_725_000_123_456L) }
+
+        assertTrue(result is NetworkResult.Error)
+        assertEquals("Track not found", (result as NetworkResult.Error).message)
+
+        server.shutdown()
+    }
 }

--- a/core/player/src/main/java/com/tuneflow/core/player/ListenSessionTracker.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/ListenSessionTracker.kt
@@ -1,0 +1,180 @@
+package com.tuneflow.core.player
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val MAX_LISTEN_THRESHOLD_MS = 4 * 60 * 1000L
+
+data class ScrobbleSubmission(
+    val accountKey: String,
+    val trackId: String,
+    val startedAtEpochMs: Long,
+)
+
+interface ScrobbleReporter {
+    fun currentAccountKey(): String?
+
+    suspend fun scrobble(submission: ScrobbleSubmission)
+}
+
+object NoOpScrobbleReporter : ScrobbleReporter {
+    override fun currentAccountKey(): String? = null
+
+    override suspend fun scrobble(submission: ScrobbleSubmission) = Unit
+}
+
+class ListenSessionTracker(
+    private val scope: CoroutineScope,
+    reporter: ScrobbleReporter = NoOpScrobbleReporter,
+    private val monotonicClockMs: () -> Long = { System.nanoTime() / 1_000_000L },
+    private val wallClockMs: () -> Long = System::currentTimeMillis,
+    private val onReportFailure: (Throwable) -> Unit = {},
+) {
+    private data class Session(
+        val sequence: Long,
+        val accountKey: String,
+        val trackId: String,
+        val startedAtEpochMs: Long,
+        var durationMs: Long,
+        var listenedMs: Long = 0L,
+        var playingSinceMs: Long? = null,
+        var submitted: Boolean = false,
+    )
+
+    private var reporter = reporter
+    private var session: Session? = null
+    private var thresholdJob: Job? = null
+    private var nextSequence = 0L
+
+    fun setReporter(reporter: ScrobbleReporter) {
+        this.reporter = reporter
+    }
+
+    fun onPlaying(
+        trackId: String,
+        durationMs: Long,
+    ) {
+        val accountKey =
+            reporter.currentAccountKey() ?: run {
+                reset()
+                return
+            }
+        val active =
+            session
+                ?.takeIf { it.trackId == trackId && it.accountKey == accountKey }
+                ?: startSession(accountKey, trackId, durationMs)
+        val previousThreshold = active.thresholdMs()
+        if (durationMs > 0L) active.durationMs = durationMs
+        if (active.submitted) return
+        if (active.playingSinceMs == null) active.playingSinceMs = monotonicClockMs()
+        if (previousThreshold != active.thresholdMs() || thresholdJob == null) {
+            scheduleThreshold(active)
+        }
+    }
+
+    fun onPaused(trackId: String) {
+        val active = session?.takeIf { it.trackId == trackId } ?: return
+        stopClock(active)
+    }
+
+    fun onEnded(trackId: String? = null) {
+        val active = session ?: return
+        if (trackId != null && active.trackId != trackId) return
+        stopClock(active)
+        if (!active.submitted && (active.durationMs <= 0L || active.listenedMs >= active.thresholdMs())) {
+            qualify(active)
+        }
+        session = null
+    }
+
+    fun onMediaChanged(
+        trackId: String?,
+        forceNewSession: Boolean = false,
+    ) {
+        val active = session ?: return
+        if (forceNewSession || active.trackId != trackId) reset()
+    }
+
+    fun reset() {
+        thresholdJob?.cancel()
+        thresholdJob = null
+        session = null
+    }
+
+    private fun startSession(
+        accountKey: String,
+        trackId: String,
+        durationMs: Long,
+    ): Session {
+        reset()
+        return Session(
+            sequence = ++nextSequence,
+            accountKey = accountKey,
+            trackId = trackId,
+            startedAtEpochMs = wallClockMs(),
+            durationMs = durationMs.coerceAtLeast(0L),
+        ).also { session = it }
+    }
+
+    private fun stopClock(active: Session) {
+        val playingSinceMs = active.playingSinceMs ?: return
+        active.listenedMs += (monotonicClockMs() - playingSinceMs).coerceAtLeast(0L)
+        active.playingSinceMs = null
+        thresholdJob?.cancel()
+        thresholdJob = null
+    }
+
+    private fun scheduleThreshold(active: Session) {
+        thresholdJob?.cancel()
+        val elapsed = active.listenedMs + active.currentPlayingTimeMs()
+        val remainingMs = (active.thresholdMs() - elapsed).coerceAtLeast(0L)
+        val sequence = active.sequence
+        thresholdJob =
+            scope.launch {
+                delay(remainingMs)
+                val current = session?.takeIf { it.sequence == sequence } ?: return@launch
+                if (current.playingSinceMs == null) return@launch
+                stopClock(current)
+                if (current.listenedMs >= current.thresholdMs()) qualify(current)
+            }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun qualify(active: Session) {
+        if (active.submitted) return
+        if (reporter.currentAccountKey() != active.accountKey) {
+            reset()
+            return
+        }
+        active.submitted = true
+        thresholdJob?.cancel()
+        thresholdJob = null
+        val submission =
+            ScrobbleSubmission(
+                accountKey = active.accountKey,
+                trackId = active.trackId,
+                startedAtEpochMs = active.startedAtEpochMs,
+            )
+        scope.launch {
+            try {
+                reporter.scrobble(submission)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                onReportFailure(error)
+            }
+        }
+    }
+
+    private fun Session.currentPlayingTimeMs(): Long = playingSinceMs?.let { (monotonicClockMs() - it).coerceAtLeast(0L) } ?: 0L
+
+    private fun Session.thresholdMs(): Long =
+        if (durationMs > 0L) {
+            (durationMs / 2L).coerceAtLeast(1L).coerceAtMost(MAX_LISTEN_THRESHOLD_MS)
+        } else {
+            MAX_LISTEN_THRESHOLD_MS
+        }
+}

--- a/core/player/src/main/java/com/tuneflow/core/player/ListenSessionTracker.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/ListenSessionTracker.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-private const val MAX_LISTEN_THRESHOLD_MS = 4 * 60 * 1000L
+private const val LISTEN_THRESHOLD_CAP_MS = 60 * 1000L
 
 data class ScrobbleSubmission(
     val accountKey: String,
@@ -173,8 +173,8 @@ class ListenSessionTracker(
 
     private fun Session.thresholdMs(): Long =
         if (durationMs > 0L) {
-            (durationMs / 2L).coerceAtLeast(1L).coerceAtMost(MAX_LISTEN_THRESHOLD_MS)
+            (durationMs / 4L).coerceAtLeast(1L).coerceAtMost(LISTEN_THRESHOLD_CAP_MS)
         } else {
-            MAX_LISTEN_THRESHOLD_MS
+            LISTEN_THRESHOLD_CAP_MS
         }
 }

--- a/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
+++ b/core/player/src/main/java/com/tuneflow/core/player/TvPlayerManager.kt
@@ -26,12 +26,14 @@ import kotlinx.coroutines.launch
 class TvPlayerManager(
     context: Context,
     private val queueStore: QueueStore,
+    scrobbleReporter: ScrobbleReporter = NoOpScrobbleReporter,
 ) : PlaybackController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val appContext = context.applicationContext
     private var lastError: PlaybackException? = null
     private var expectedToPlay = false
     private var fallbackMonitorJob: Job? = null
+    private val listenSessionTracker = ListenSessionTracker(scope, scrobbleReporter)
 
     private val _queue = MutableStateFlow(PlaybackQueue())
     override val queue: StateFlow<PlaybackQueue> = _queue.asStateFlow()
@@ -68,10 +70,14 @@ class TvPlayerManager(
                         override fun onIsPlayingChanged(isPlaying: Boolean) {
                             _isPlaying.value = isPlaying
                             if (isPlaying) {
+                                startCurrentListen()
                                 lastError = null
                                 cancelFallbackMonitor()
                             } else if (expectedToPlay) {
+                                pauseCurrentListen()
                                 scheduleFallbackMonitor()
+                            } else {
+                                pauseCurrentListen()
                             }
                             updatePlaybackStatus()
                         }
@@ -79,23 +85,28 @@ class TvPlayerManager(
                         override fun onPlaybackStateChanged(playbackState: Int) {
                             when (playbackState) {
                                 Player.STATE_BUFFERING -> {
+                                    pauseCurrentListen()
                                     if (expectedToPlay) scheduleFallbackMonitor()
                                 }
                                 Player.STATE_READY -> {
                                     if (exo.isPlaying) {
+                                        startCurrentListen()
                                         lastError = null
                                         cancelFallbackMonitor()
                                     } else if (expectedToPlay) {
+                                        pauseCurrentListen()
                                         scheduleFallbackMonitor()
                                     }
                                 }
                                 Player.STATE_ENDED -> {
+                                    endCurrentListen()
                                     if (_playbackMode.value != PlaybackMode.Loop) {
                                         expectedToPlay = false
                                         cancelFallbackMonitor()
                                     }
                                 }
                                 Player.STATE_IDLE -> {
+                                    pauseCurrentListen()
                                     if (expectedToPlay) scheduleFallbackMonitor()
                                 }
                             }
@@ -108,6 +119,7 @@ class TvPlayerManager(
                             reason: Int,
                         ) {
                             if (!playWhenReady && !exo.isPlaying) {
+                                pauseCurrentListen()
                                 expectedToPlay = false
                                 cancelFallbackMonitor()
                             }
@@ -118,7 +130,17 @@ class TvPlayerManager(
                             mediaItem: MediaItem?,
                             reason: Int,
                         ) {
+                            if (reason.isNaturalTransition()) {
+                                endCurrentListen()
+                            }
                             updateQueueIndex(exo.currentMediaItemIndex)
+                            listenSessionTracker.onMediaChanged(
+                                trackId = mediaItem?.mediaId,
+                                forceNewSession = reason != Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED,
+                            )
+                            if (exo.isPlaying) {
+                                startCurrentListen()
+                            }
                             if (expectedToPlay) {
                                 scheduleFallbackMonitor()
                             }
@@ -140,6 +162,7 @@ class TvPlayerManager(
                         }
 
                         override fun onPlayerError(error: PlaybackException) {
+                            pauseCurrentListen()
                             lastError = error
                             if (!tryFallbackForCurrentItem()) {
                                 _isPlaying.value = false
@@ -176,6 +199,7 @@ class TvPlayerManager(
     ) {
         if (items.isEmpty()) return
 
+        listenSessionTracker.reset()
         val queue = PlaybackQueue().replace(items, startIndex, sourcePlaylistName)
         _queue.value = queue
         lastError = null
@@ -201,6 +225,7 @@ class TvPlayerManager(
     }
 
     override fun pause() {
+        pauseCurrentListen()
         expectedToPlay = false
         player.pause()
         cancelFallbackMonitor()
@@ -219,6 +244,7 @@ class TvPlayerManager(
         if (queue.items.isEmpty()) return
 
         val clamped = index.coerceIn(0, queue.items.lastIndex)
+        listenSessionTracker.reset()
         lastError = null
         expectedToPlay = true
         player.seekToDefaultPosition(clamped)
@@ -247,6 +273,7 @@ class TvPlayerManager(
     }
 
     override fun stopAndClear() {
+        listenSessionTracker.reset()
         expectedToPlay = false
         lastError = null
         cancelFallbackMonitor()
@@ -263,6 +290,7 @@ class TvPlayerManager(
     }
 
     override fun next() {
+        listenSessionTracker.reset()
         lastError = null
         expectedToPlay = player.playWhenReady || _isPlaying.value
         player.seekToNextMediaItem()
@@ -273,6 +301,7 @@ class TvPlayerManager(
     }
 
     override fun previous() {
+        listenSessionTracker.reset()
         lastError = null
         expectedToPlay = player.playWhenReady || _isPlaying.value
         player.seekToPreviousMediaItem()
@@ -327,10 +356,33 @@ class TvPlayerManager(
     }
 
     fun release() {
+        listenSessionTracker.reset()
         cancelFallbackMonitor()
         persist()
         player.release()
     }
+
+    fun setScrobbleReporter(reporter: ScrobbleReporter) {
+        listenSessionTracker.setReporter(reporter)
+        if (player.isPlaying) startCurrentListen()
+    }
+
+    private fun startCurrentListen() {
+        val track = _queue.value.currentItem ?: return
+        listenSessionTracker.onPlaying(track.id, track.durationMs)
+    }
+
+    private fun pauseCurrentListen() {
+        _queue.value.currentItem?.let { listenSessionTracker.onPaused(it.id) }
+    }
+
+    private fun endCurrentListen() {
+        listenSessionTracker.onEnded()
+    }
+
+    private fun Int.isNaturalTransition(): Boolean =
+        this == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ||
+            this == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT
 
     private fun scheduleFallbackMonitor() {
         cancelFallbackMonitor()

--- a/core/player/src/test/java/com/tuneflow/core/player/ListenSessionTrackerTest.kt
+++ b/core/player/src/test/java/com/tuneflow/core/player/ListenSessionTrackerTest.kt
@@ -1,0 +1,180 @@
+package com.tuneflow.core.player
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListenSessionTrackerTest {
+    @Test
+    fun `submits once after half of a normal track`() =
+        runTest {
+            val reporter = RecordingScrobbleReporter()
+            val tracker = tracker(reporter)
+
+            tracker.onPlaying("track-id", 180_000L)
+            advanceTimeBy(89_999L)
+            runCurrent()
+            assertTrue(reporter.submissions.isEmpty())
+
+            advanceTimeBy(1L)
+            runCurrent()
+            tracker.onPlaying("track-id", 180_000L)
+            advanceTimeBy(90_000L)
+            runCurrent()
+
+            assertEquals(
+                listOf(ScrobbleSubmission("server\u0000user", "track-id", 1_234_567L)),
+                reporter.submissions,
+            )
+        }
+
+    @Test
+    fun `pause and buffering time do not qualify a listen`() =
+        runTest {
+            val reporter = RecordingScrobbleReporter()
+            val tracker = tracker(reporter)
+
+            tracker.onPlaying("track-id", 100_000L)
+            advanceTimeBy(25_000L)
+            tracker.onPaused("track-id")
+            advanceTimeBy(100_000L)
+            runCurrent()
+            assertTrue(reporter.submissions.isEmpty())
+
+            tracker.onPlaying("track-id", 100_000L)
+            advanceTimeBy(25_000L)
+            runCurrent()
+
+            assertEquals(1, reporter.submissions.size)
+        }
+
+    @Test
+    fun `four minute cap applies to long media`() =
+        runTest {
+            val reporter = RecordingScrobbleReporter()
+            val tracker = tracker(reporter)
+
+            tracker.onPlaying("long-track", 900_000L)
+            advanceTimeBy(239_999L)
+            runCurrent()
+            assertTrue(reporter.submissions.isEmpty())
+
+            advanceTimeBy(1L)
+            runCurrent()
+
+            assertEquals(1, reporter.submissions.size)
+        }
+
+    @Test
+    fun `unknown duration qualifies only on natural end or four minutes`() =
+        runTest {
+            val reporter = RecordingScrobbleReporter()
+            val tracker = tracker(reporter)
+
+            tracker.onPlaying("unknown-track", 0L)
+            advanceTimeBy(1_000L)
+            tracker.onEnded()
+            runCurrent()
+
+            assertEquals(1, reporter.submissions.size)
+        }
+
+    @Test
+    fun `early end reset and account change do not submit`() =
+        runTest {
+            val reporter = RecordingScrobbleReporter()
+            val tracker = tracker(reporter)
+
+            tracker.onPlaying("known-track", 180_000L)
+            advanceTimeBy(10_000L)
+            tracker.onEnded("known-track")
+            tracker.onPlaying("skipped-track", 180_000L)
+            advanceTimeBy(10_000L)
+            tracker.reset()
+            tracker.onPlaying("changed-account-track", 2_000L)
+            reporter.accountKey = "server\u0000other"
+            advanceTimeBy(1_000L)
+            runCurrent()
+
+            assertTrue(reporter.submissions.isEmpty())
+        }
+
+    @Test
+    fun `same media fallback stays in session but repeat starts a new one`() =
+        runTest {
+            val reporter = RecordingScrobbleReporter()
+            val tracker = tracker(reporter)
+
+            tracker.onPlaying("track-id", 100_000L)
+            advanceTimeBy(25_000L)
+            tracker.onMediaChanged("track-id")
+            advanceTimeBy(25_000L)
+            runCurrent()
+            assertEquals(1, reporter.submissions.size)
+
+            tracker.onMediaChanged("track-id", forceNewSession = true)
+            tracker.onPlaying("track-id", 100_000L)
+            advanceTimeBy(50_000L)
+            runCurrent()
+
+            assertEquals(2, reporter.submissions.size)
+        }
+
+    @Test
+    fun `report failure is isolated and never retried`() =
+        runTest {
+            var attempts = 0
+            var failures = 0
+            val reporter =
+                object : ScrobbleReporter {
+                    override fun currentAccountKey(): String = "server\u0000user"
+
+                    override suspend fun scrobble(submission: ScrobbleSubmission) {
+                        attempts += 1
+                        error("offline")
+                    }
+                }
+            val tracker =
+                ListenSessionTracker(
+                    scope = backgroundScope,
+                    reporter = reporter,
+                    monotonicClockMs = { testScheduler.currentTime },
+                    wallClockMs = { 1_234_567L },
+                    onReportFailure = { failures += 1 },
+                )
+
+            tracker.onPlaying("track-id", 2_000L)
+            advanceTimeBy(1_000L)
+            runCurrent()
+            tracker.onPlaying("track-id", 2_000L)
+            advanceTimeBy(2_000L)
+            runCurrent()
+
+            assertEquals(1, attempts)
+            assertEquals(1, failures)
+        }
+
+    private fun kotlinx.coroutines.test.TestScope.tracker(reporter: RecordingScrobbleReporter) =
+        ListenSessionTracker(
+            scope = backgroundScope,
+            reporter = reporter,
+            monotonicClockMs = { testScheduler.currentTime },
+            wallClockMs = { 1_234_567L },
+        )
+}
+
+private class RecordingScrobbleReporter : ScrobbleReporter {
+    var accountKey: String? = "server\u0000user"
+    val submissions = mutableListOf<ScrobbleSubmission>()
+
+    override fun currentAccountKey(): String? = accountKey
+
+    override suspend fun scrobble(submission: ScrobbleSubmission) {
+        submissions += submission
+    }
+}

--- a/core/player/src/test/java/com/tuneflow/core/player/ListenSessionTrackerTest.kt
+++ b/core/player/src/test/java/com/tuneflow/core/player/ListenSessionTrackerTest.kt
@@ -11,20 +11,20 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class ListenSessionTrackerTest {
     @Test
-    fun `submits once after half of a normal track`() =
+    fun `submits once after quarter of a normal track`() =
         runTest {
             val reporter = RecordingScrobbleReporter()
             val tracker = tracker(reporter)
 
             tracker.onPlaying("track-id", 180_000L)
-            advanceTimeBy(89_999L)
+            advanceTimeBy(44_999L)
             runCurrent()
             assertTrue(reporter.submissions.isEmpty())
 
             advanceTimeBy(1L)
             runCurrent()
             tracker.onPlaying("track-id", 180_000L)
-            advanceTimeBy(90_000L)
+            advanceTimeBy(45_000L)
             runCurrent()
 
             assertEquals(
@@ -40,27 +40,27 @@ class ListenSessionTrackerTest {
             val tracker = tracker(reporter)
 
             tracker.onPlaying("track-id", 100_000L)
-            advanceTimeBy(25_000L)
+            advanceTimeBy(12_500L)
             tracker.onPaused("track-id")
             advanceTimeBy(100_000L)
             runCurrent()
             assertTrue(reporter.submissions.isEmpty())
 
             tracker.onPlaying("track-id", 100_000L)
-            advanceTimeBy(25_000L)
+            advanceTimeBy(12_500L)
             runCurrent()
 
             assertEquals(1, reporter.submissions.size)
         }
 
     @Test
-    fun `four minute cap applies to long media`() =
+    fun `one minute cap applies to long media`() =
         runTest {
             val reporter = RecordingScrobbleReporter()
             val tracker = tracker(reporter)
 
             tracker.onPlaying("long-track", 900_000L)
-            advanceTimeBy(239_999L)
+            advanceTimeBy(59_999L)
             runCurrent()
             assertTrue(reporter.submissions.isEmpty())
 
@@ -71,7 +71,7 @@ class ListenSessionTrackerTest {
         }
 
     @Test
-    fun `unknown duration qualifies only on natural end or four minutes`() =
+    fun `unknown duration qualifies on natural end or one minute`() =
         runTest {
             val reporter = RecordingScrobbleReporter()
             val tracker = tracker(reporter)
@@ -82,6 +82,15 @@ class ListenSessionTrackerTest {
             runCurrent()
 
             assertEquals(1, reporter.submissions.size)
+
+            tracker.onPlaying("unknown-timer", 0L)
+            advanceTimeBy(59_999L)
+            runCurrent()
+            assertEquals(1, reporter.submissions.size)
+
+            advanceTimeBy(1L)
+            runCurrent()
+            assertEquals(2, reporter.submissions.size)
         }
 
     @Test
@@ -111,15 +120,15 @@ class ListenSessionTrackerTest {
             val tracker = tracker(reporter)
 
             tracker.onPlaying("track-id", 100_000L)
-            advanceTimeBy(25_000L)
+            advanceTimeBy(12_500L)
             tracker.onMediaChanged("track-id")
-            advanceTimeBy(25_000L)
+            advanceTimeBy(12_500L)
             runCurrent()
             assertEquals(1, reporter.submissions.size)
 
             tracker.onMediaChanged("track-id", forceNewSession = true)
             tracker.onPlaying("track-id", 100_000L)
-            advanceTimeBy(50_000L)
+            advanceTimeBy(25_000L)
             runCurrent()
 
             assertEquals(2, reporter.submissions.size)

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoListenSession.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoListenSession.kt
@@ -1,0 +1,44 @@
+package com.tuneflow.feature.video
+
+import com.tuneflow.core.player.ListenSessionTracker
+import com.tuneflow.core.player.ScrobbleReporter
+import kotlinx.coroutines.CoroutineScope
+
+internal class VideoListenSession(
+    scope: CoroutineScope,
+    reporter: ScrobbleReporter,
+    diagnostic: (String) -> Unit,
+) {
+    private val tracker =
+        ListenSessionTracker(
+            scope = scope,
+            reporter = reporter,
+            onReportFailure = { diagnostic("Navidrome video scrobble failed; playback continues.") },
+        )
+
+    fun onPlayerState(
+        state: NativeVideoPlayerState,
+        fallbackDurationMs: Long,
+    ) {
+        when (state) {
+            is NativeVideoPlayerState.Playing ->
+                tracker.onPlaying(
+                    state.session.trackId,
+                    state.durationMs.takeIf { it > 0L } ?: fallbackDurationMs,
+                )
+            is NativeVideoPlayerState.Ready -> tracker.onPaused(state.session.trackId)
+            is NativeVideoPlayerState.Paused -> tracker.onPaused(state.session.trackId)
+            is NativeVideoPlayerState.Buffering -> tracker.onPaused(state.session.trackId)
+            is NativeVideoPlayerState.Loading -> tracker.onPaused(state.session.trackId)
+            is NativeVideoPlayerState.Ended -> tracker.onEnded(state.session.trackId)
+            is NativeVideoPlayerState.Error -> tracker.reset()
+            NativeVideoPlayerState.Idle -> Unit
+        }
+    }
+
+    fun pause(trackId: String?) {
+        trackId?.let(tracker::onPaused)
+    }
+
+    fun reset() = tracker.reset()
+}

--- a/feature/video/src/main/java/com/tuneflow/feature/video/VideoViewModel.kt
+++ b/feature/video/src/main/java/com/tuneflow/feature/video/VideoViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tuneflow.core.player.PlaybackController
 import com.tuneflow.core.player.PlaybackQueue
+import com.tuneflow.core.player.ScrobbleReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -18,11 +19,13 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.Locale
 
+@Suppress("LargeClass")
 class VideoViewModel(
     private val audio: PlaybackController,
     private val consentStore: VideoConsentStore,
     private val nativeBackend: NativeVideoBackend,
     private val preferredVideoStore: PreferredVideoStore = UnavailablePreferredVideoStore,
+    scrobbleReporter: ScrobbleReporter,
     private val scopeOverride: CoroutineScope? = null,
     private val diagnostic: (String) -> Unit = { message -> Log.w(VIDEO_LOG_TAG, message) },
 ) : ViewModel() {
@@ -51,6 +54,7 @@ class VideoViewModel(
 
     private var searchJob: Job? = null
     private val persistenceMutex = Mutex()
+    private val listenSession = VideoListenSession(scope, scrobbleReporter, diagnostic)
     private var generation = 0L
     private var nowPlayingVisible = false
     private var activeCandidate: VideoCandidate? = null
@@ -197,6 +201,7 @@ class VideoViewModel(
         enableVideoPreferred: Boolean = false,
         automatic: Boolean = false,
     ) {
+        listenSession.reset()
         if (_uiState.value.isVideoSessionActive) releaseVideoPlayer()
         generation += 1
         val queuePosition = audio.queue.value.toVideoQueuePosition()
@@ -340,7 +345,10 @@ class VideoViewModel(
     fun previousTrack(): Boolean = moveFromVideoToQueue(audio::previous)
 
     fun onAppBackgrounded() {
-        if (_uiState.value is VideoUiState.Playing) activePlayer().pause()
+        if (_uiState.value is VideoUiState.Playing) {
+            listenSession.pause(_uiState.value.trackId)
+            activePlayer().pause()
+        }
     }
 
     private fun search(
@@ -438,6 +446,9 @@ class VideoViewModel(
         playerState: NativeVideoPlayerState,
     ) {
         if (source !== activePlayer()) return
+        if (playerState.sessionOrNull()?.let(::isCurrentSession) == true) {
+            listenSession.onPlayerState(playerState, activeCandidate?.durationMs ?: 0L)
+        }
         when (playerState) {
             is NativeVideoPlayerState.Ready -> onPlayerReady(playerState)
             is NativeVideoPlayerState.Playing -> updatePlayingState(playerState, isPlaying = true)
@@ -567,6 +578,7 @@ class VideoViewModel(
 
     private fun releaseVideoPlayer() {
         searchJob?.cancel()
+        listenSession.reset()
         activePlayer().release()
     }
 

--- a/feature/video/src/test/java/com/tuneflow/feature/video/VideoViewModelTest.kt
+++ b/feature/video/src/test/java/com/tuneflow/feature/video/VideoViewModelTest.kt
@@ -2,11 +2,14 @@ package com.tuneflow.feature.video
 
 import android.content.Context
 import android.view.View
+import com.tuneflow.core.player.NoOpScrobbleReporter
 import com.tuneflow.core.player.PlaybackController
 import com.tuneflow.core.player.PlaybackMode
 import com.tuneflow.core.player.PlaybackQueue
 import com.tuneflow.core.player.PlaybackStatus
 import com.tuneflow.core.player.QueueItem
+import com.tuneflow.core.player.ScrobbleReporter
+import com.tuneflow.core.player.ScrobbleSubmission
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -363,6 +366,49 @@ class VideoViewModelTest {
         }
 
     @Test
+    fun completedTrackLinkedVideoScrobblesNavidromeTrackId() =
+        runTest {
+            val audio =
+                VideoViewModelFakeAudio(
+                    PlaybackQueue(
+                        items =
+                            listOf(
+                                QueueItem(
+                                    id = "video-track-id",
+                                    title = "Track",
+                                    artist = "Artist",
+                                    album = "Album",
+                                    streamUrl = "stream",
+                                    durationMs = 0L,
+                                ),
+                            ),
+                    ),
+                )
+            val nativePlayer = FakeNativePlayer()
+            val reporter = RecordingVideoScrobbleReporter()
+            val viewModel =
+                createViewModel(
+                    audio = audio,
+                    scope = backgroundScope,
+                    nativeBackend = FakeNativeBackend(nativePlayer),
+                    scrobbleReporter = reporter,
+                )
+            runCurrent()
+
+            viewModel.requestVideo()
+            runCurrent()
+            viewModel.selectCandidate((viewModel.uiState.value as VideoUiState.Candidates).candidates.first())
+            nativePlayer.emitPlaying(positionMs = 0L, durationMs = 0L)
+            runCurrent()
+            advanceTimeBy(1_000L)
+            nativePlayer.emitEnded(positionMs = 1_000L, durationMs = 0L)
+            runCurrent()
+
+            assertEquals(1, reporter.submissions.size)
+            assertEquals("video-track-id", reporter.submissions.single().trackId)
+        }
+
+    @Test
     fun trackChangeReleasesNativeSession() =
         runTest {
             val audio = VideoViewModelFakeAudio()
@@ -564,12 +610,14 @@ class VideoViewModelTest {
         scope: CoroutineScope,
         nativeBackend: NativeVideoBackend = FakeNativeBackend(),
         preferredVideoStore: PreferredVideoStore = FakePreferredVideoStore(),
+        scrobbleReporter: ScrobbleReporter = NoOpScrobbleReporter,
     ): VideoViewModel =
         VideoViewModel(
             audio = audio,
             consentStore = AcceptedConsentStore,
             nativeBackend = nativeBackend,
             preferredVideoStore = preferredVideoStore,
+            scrobbleReporter = scrobbleReporter,
             scopeOverride = scope,
             diagnostic = {},
         )
@@ -682,8 +730,21 @@ private class FakeNativePlayer : NativeVideoPlayer {
         mutableState.value = NativeVideoPlayerState.Playing(requireNotNull(session), positionMs, durationMs)
     }
 
-    fun emitEnded() {
-        mutableState.value = NativeVideoPlayerState.Ended(requireNotNull(session), 180_000L, 180_000L)
+    fun emitEnded(
+        positionMs: Long = 180_000L,
+        durationMs: Long = 180_000L,
+    ) {
+        mutableState.value = NativeVideoPlayerState.Ended(requireNotNull(session), positionMs, durationMs)
+    }
+}
+
+private class RecordingVideoScrobbleReporter : ScrobbleReporter {
+    val submissions = mutableListOf<ScrobbleSubmission>()
+
+    override fun currentAccountKey(): String = "server\u0000user"
+
+    override suspend fun scrobble(submission: ScrobbleSubmission) {
+        submissions += submission
     }
 }
 


### PR DESCRIPTION
## Summary

- add the authenticated Navidrome `scrobble` request with the original playback-start timestamp
- track actual playing time for audio and track-linked native video
- submit the Navidrome track ID once at 25% played or one minute, whichever comes first
- handle automatic advance, repeat, stream fallback, pause, buffering, video loading, and account changes without duplicate or cross-account submissions

## Stability decisions

- in-memory, one timer per active session; no polling, database, WorkManager, persistence, or retry queue
- no `submission=false` traffic
- server and transport failures are diagnostic-only and cannot affect playback
- manual skips and failures reset tracking; natural end closes the current session
- existing `stopAndClear()` exit behavior remains unchanged
- track-linked video uses the underlying Navidrome track ID; per-YouTube-video analytics remains separate

## Verification

- `./gradlew :app:assembleDebug test lintDebug ktlintCheck detekt --console=plain`
- tracker tests cover quarter-duration, one-minute cap, pause/buffering accounting, fallback, repeat, account change, unknown duration, and failure isolation
- MockWebServer tests cover exact request parameters and Subsonic server errors
- video ViewModel test verifies completed video submits its linked Navidrome track ID

Closes #154